### PR TITLE
✨ Feature: #1 Domain Entitiy 정의

### DIFF
--- a/RetroApp/RetroApp/Domain/Entities/Enums.swift
+++ b/RetroApp/RetroApp/Domain/Entities/Enums.swift
@@ -1,0 +1,53 @@
+//
+//  Enums.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// 회고의 상태를 나타내는 열거형
+///
+/// 회고는 `draft`로 생성되어, 제출 시 `confirmed`로 전환된다.
+/// 한번 `confirmed`되면 `draft`로 되돌릴 수 없다.
+enum RetrospectStatus: String {
+
+    /// 작성 중 상태. 수정 및 삭제 가능.
+    case draft
+
+    /// 제출 완료 상태. 수정 불가, 삭제만 가능.
+    case confirmed
+}
+
+/// 회고의 유형을 나타내는 열거형.
+enum RetrospectType: String {
+
+    /// 개인 회고. 로그인 없이 로컬에서 사용 가능.
+    case personal
+
+    /// 팀 회고. 로그인 필수, ``RetrospectSession``에 소속.
+    case team
+}
+
+/// 팀 회고 세션의 상태를 나타내는 열거형.
+///
+/// 세션은 `inProgress`로 시작되어, 모든 팀원이 제출하면 `completed`로 전환된다.
+enum SessionStatus: String {
+
+    /// 진행 중. 팀원들이 작성 및 제출 가능.
+    case inProgress
+
+    /// 완료. 전원 제출 완료. 더 이상 수정/제출 불가.
+    case completed
+}
+
+/// 팀 회고에서 개별 팀원의 제출 상태를 나타내는 열거형.
+enum SubmissionStatus: String {
+
+    /// 작성 중. typing indicator가 표시될 수 있다.
+    case writing
+
+    /// 제출 완료. 수정 불가.
+    case submitted
+}

--- a/RetroApp/RetroApp/Domain/Entities/Enums.swift
+++ b/RetroApp/RetroApp/Domain/Entities/Enums.swift
@@ -7,22 +7,20 @@
 
 import Foundation
 
-/// 회고의 상태를 나타내는 열거형
+/// 회고의 상태를 나타내는 열거형.
 ///
 /// 회고는 `draft`로 생성되어, 제출 시 `confirmed`로 전환된다.
 /// 한번 `confirmed`되면 `draft`로 되돌릴 수 없다.
-enum RetrospectStatus: String {
-
-    /// 작성 중 상태. 수정 및 삭제 가능.
+enum RetrospectStatus: String, Sendable, Codable, CaseIterable {
+    /// 작성 중 상태. 자유롭게 수정 가능.
     case draft
 
-    /// 제출 완료 상태. 수정 불가, 삭제만 가능.
+    /// 제출 완료 상태. 수정 가능하지만 `isEdited` 플래그가 설정됨.
     case confirmed
 }
 
 /// 회고의 유형을 나타내는 열거형.
-enum RetrospectType: String {
-
+enum RetrospectType: String, Sendable, Codable, CaseIterable {
     /// 개인 회고. 로그인 없이 로컬에서 사용 가능.
     case personal
 
@@ -33,8 +31,7 @@ enum RetrospectType: String {
 /// 팀 회고 세션의 상태를 나타내는 열거형.
 ///
 /// 세션은 `inProgress`로 시작되어, 모든 팀원이 제출하면 `completed`로 전환된다.
-enum SessionStatus: String {
-
+enum SessionStatus: String, Sendable, Codable, CaseIterable {
     /// 진행 중. 팀원들이 작성 및 제출 가능.
     case inProgress
 
@@ -43,11 +40,24 @@ enum SessionStatus: String {
 }
 
 /// 팀 회고에서 개별 팀원의 제출 상태를 나타내는 열거형.
-enum SubmissionStatus: String {
-
+enum SubmissionStatus: String, Sendable, Codable, CaseIterable {
     /// 작성 중. typing indicator가 표시될 수 있다.
     case writing
 
     /// 제출 완료. 수정 불가.
     case submitted
+}
+
+/// CSS 피어 피드백의 카테고리를 나타내는 열거형.
+///
+/// Continue/Stop/Start 방법론에 기반한다.
+enum PeerFeedbackCategory: String, Sendable, Codable, CaseIterable {
+    /// 계속 해줬으면 하는 행동
+    case continueDoing
+
+    /// 그만 해줬으면 하는 행동
+    case stopDoing
+
+    /// 새로 시작해줬으면 하는 행동
+    case startDoing
 }

--- a/RetroApp/RetroApp/Domain/Entities/PeerFeedback.swift
+++ b/RetroApp/RetroApp/Domain/Entities/PeerFeedback.swift
@@ -1,0 +1,75 @@
+//
+//  PeerFeedback.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// CSS(Continue/Stop/Start) 피어 피드백을 나타내는 Domain Entity.
+///
+/// 팀 회고 세션 후 팀원 간에 주고받는 행동 피드백이다.
+/// 한 팀원이 다른 팀원에게 "계속 해줘 / 그만 해줘 / 새로 해줘"를 전달한다.
+///
+/// ## 익명 설정
+/// 세션의 ``RetrospectSession/isAnonymousFeedback``가 `true`이면,
+/// ``fromUserId``가 수신자에게 공개되지 않는다.
+/// Presentation 레이어에서 익명 여부에 따라 표시를 분기한다.
+///
+/// ## 예시
+/// ```
+/// 진영 → 민지:
+///   Continue: "코드 리뷰 꼼꼼하게 해주는 거"
+///   Stop: "회의 중에 말 끊기"
+///   Start: "PR 설명 좀 더 자세히 써주기"
+/// ```
+struct PeerFeedback {
+
+    /// 피드백 고유 식별자
+    let id: UUID
+
+    /// 피드백이 작성된 세션의 식별자
+    ///
+    /// ``RetrospectSession``의 `id`를 참조한다.
+    let sessionId: UUID
+
+    /// 피드백 작성자의 사용자 식별자
+    ///
+    /// 익명 모드에서는 수신자에게 공개되지 않는다.
+    let fromUserId: String
+
+    /// 피드백 수신자의 사용자 식별자
+    let toUserId: String
+
+    /// 피드백 카테고리
+    ///
+    /// CSS(Continue/Stop/Start) 중 하나.
+    let category: PeerFeedbackCategory
+
+    /// 피드백 내용
+    let content: String
+
+    /// 익명 여부
+    ///
+    /// 세션의 ``RetrospectSession/isAnonymousFeedback`` 설정을 따른다.
+    let isAnonymous: Bool
+
+    /// 피드백 작성 시각
+    let createdAt: Date
+}
+
+/// CSS 피어 피드백의 카테고리를 나타내는 열거형.
+///
+/// Continue/Stop/Start 방법론에 기반한다.
+enum PeerFeedbackCategory: String {
+
+    /// 계속 해줬으면 하는 행동
+    case continueDoing
+
+    /// 그만 해줬으면 하는 행동
+    case stopDoing
+
+    /// 새로 시작해줬으면 하는 행동
+    case startDoing
+}

--- a/RetroApp/RetroApp/Domain/Entities/PeerFeedback.swift
+++ b/RetroApp/RetroApp/Domain/Entities/PeerFeedback.swift
@@ -24,7 +24,7 @@ import Foundation
 ///   Stop: "회의 중에 말 끊기"
 ///   Start: "PR 설명 좀 더 자세히 써주기"
 /// ```
-struct PeerFeedback {
+struct PeerFeedback: Sendable, Equatable, Identifiable {
 
     /// 피드백 고유 식별자
     let id: UUID
@@ -57,19 +57,4 @@ struct PeerFeedback {
 
     /// 피드백 작성 시각
     let createdAt: Date
-}
-
-/// CSS 피어 피드백의 카테고리를 나타내는 열거형.
-///
-/// Continue/Stop/Start 방법론에 기반한다.
-enum PeerFeedbackCategory: String {
-
-    /// 계속 해줬으면 하는 행동
-    case continueDoing
-
-    /// 그만 해줬으면 하는 행동
-    case stopDoing
-
-    /// 새로 시작해줬으면 하는 행동
-    case startDoing
 }

--- a/RetroApp/RetroApp/Domain/Entities/Retrospect.swift
+++ b/RetroApp/RetroApp/Domain/Entities/Retrospect.swift
@@ -12,7 +12,7 @@ import Foundation
 /// 사용자가 작성한 회고의 메타 정보를 담고 있으며,
 /// 실제 항목(Keep, Problem, Try 등)은 ``RetrospectItem``으로 분리되어 1:N 관계를 가진다.
 ///
-struct Retrospect {
+struct Retrospect: Sendable, Equatable, Identifiable {
 
     /// 회고 고유 식별자
     let id: UUID

--- a/RetroApp/RetroApp/Domain/Entities/Retrospect.swift
+++ b/RetroApp/RetroApp/Domain/Entities/Retrospect.swift
@@ -1,0 +1,76 @@
+//
+//  Retrospect.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// 하나의 회고를 나타내는 Domain Entity.
+///
+/// 사용자가 작성한 회고의 메타 정보를 담고 있으며,
+/// 실제 항목(Keep, Problem, Try 등)은 ``RetrospectItem``으로 분리되어 1:N 관계를 가진다.
+///
+struct Retrospect {
+
+    /// 회고 고유 식별자
+    let id: UUID
+
+    /// 회고 제목
+    ///
+    /// 사용자가 입력하지 않으면 `nil`.
+    /// 목록에서는 `nil`일 경우 생성 날짜로 표시한다.
+    /// 예: "2026년 3월 20일 회고"
+    let title: String?
+
+    /// 사용한 회고 포맷의 식별자
+    ///
+    /// ``RetrospectFormat``의 `id`를 참조한다.
+    /// 포맷에 따라 카테고리 구성이 달라진다 (KPT, 4Ls, SSC 등).
+    let formatId: UUID
+
+    /// 회고 상태
+    ///
+    /// - `draft`: 작성 중. 자유롭게 수정 가능
+    /// - `confirmed`: 제출 완료. 수정 가능하지만 `isEdited`가 `true`로 변경됨
+    let status: RetrospectStatus
+
+    /// 확정 후 수정된 적이 있는지 여부
+    ///
+    /// 확정 상태에서 수정하면 `true`로 변경된다.
+    /// 목록/상세 화면에서 "(수정됨)" 표시에 사용.
+    /// 드래프트 상태에서는 항상 `false`.
+    let isEdited: Bool
+
+    /// 회고 유형
+    ///
+    /// - `personal`: 개인 회고
+    /// - `team`: 팀 회고 (세션에 소속)
+    let type: RetrospectType
+
+    /// 팀 회고인 경우, 소속 팀의 식별자
+    ///
+    /// 개인 회고이면 `nil`.
+    let teamId: UUID?
+
+    /// 팀 회고인 경우, 소속 세션의 식별자
+    ///
+    /// ``RetrospectSession``의 `id`를 참조한다.
+    /// 개인 회고이면 `nil`.
+    let sessionId: UUID?
+
+    /// 사용한 포커스 타이머 시간 (초 단위)
+    ///
+    /// 타이머를 사용하지 않았으면 `nil`.
+    /// 프리셋: Quick(300), Normal(900), Deep(1800)
+    let timerDuration: Int?
+
+    /// 회고 생성 시각
+    let createdAt: Date
+
+    /// 회고 확정(제출) 시각
+    ///
+    /// `status`가 `.confirmed`일 때만 값이 있다.
+    let confirmedAt: Date?
+}

--- a/RetroApp/RetroApp/Domain/Entities/RetrospectFormat.swift
+++ b/RetroApp/RetroApp/Domain/Entities/RetrospectFormat.swift
@@ -18,58 +18,56 @@ import Foundation
 ///
 /// ## 추천 시스템
 /// ``recommendWhen``을 기반으로 상황별 포맷 추천 배너를 표시한다.
-struct RetrospectFormat {
- 
+struct RetrospectFormat: Sendable, Equatable, Identifiable {
     /// 포맷 고유 식별자
     let id: UUID
- 
+
     /// 포맷 이름
     ///
     /// 예: "KPT", "4Ls", "Start-Stop-Continue"
     let name: String
- 
+
     /// 포맷에 포함된 카테고리 목록
     ///
     /// 순서대로 화면에 표시된다.
     /// 예: KPT → [Keep, Problem, Try]
     let categories: [CategoryTemplate]
- 
+
     /// 기본 제공 포맷 여부
     ///
     /// `true`이면 삭제/수정 불가.
     let isBuiltIn: Bool
- 
+
     /// 포맷 설명
     ///
     /// 포맷 선택 화면에서 사용자에게 보여줄 한 줄 설명.
     /// 예: "일상적인 스프린트 회고에 적합"
     let description: String
- 
+
     /// 추천 조건 설명
     ///
     /// 어떤 상황에서 이 포맷을 추천하는지.
     /// 예: "힘든 스프린트 후 감정 정리가 필요할 때"
     let recommendWhen: String
 }
- 
+
 /// 포맷 내 개별 카테고리를 정의하는 값 객체.
 ///
 /// ``RetrospectFormat``의 ``RetrospectFormat/categories``에 포함되며,
 /// 카테고리의 이름, 색상, 표시 순서를 정의한다.
-struct CategoryTemplate {
- 
+struct CategoryTemplate: Sendable, Equatable {
     /// 카테고리 이름
     ///
     /// ``RetrospectItem``의 ``RetrospectItem/categoryName``에 저장되는 값.
     /// 예: "Keep", "Problem", "Liked"
     let name: String
- 
+
     /// 카테고리 색상 (HEX)
     ///
     /// UI에서 카테고리를 시각적으로 구분하는 데 사용한다.
     /// 예: "#10B981" (Keep 초록), "#F97316" (Problem 주황)
     let colorHex: String
- 
+
     /// 표시 순서
     ///
     /// 0부터 시작. 화면에서 카테고리가 나열되는 순서.

--- a/RetroApp/RetroApp/Domain/Entities/RetrospectFormat.swift
+++ b/RetroApp/RetroApp/Domain/Entities/RetrospectFormat.swift
@@ -1,0 +1,77 @@
+//
+//  RetrospectFormat.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// 회고 방법론(포맷)을 정의하는 Domain Entity.
+///
+/// KPT, 4Ls, Start-Stop-Continue 등 각 회고 방법론의
+/// 이름, 카테고리 구성, 설명을 담고 있다.
+///
+/// ## 빌트인 vs 커스텀
+/// - `isBuiltIn == true`: 앱에서 기본 제공하는 포맷. 삭제/수정 불가
+/// - `isBuiltIn == false`: 사용자가 직접 생성한 커스텀 포맷
+///
+/// ## 추천 시스템
+/// ``recommendWhen``을 기반으로 상황별 포맷 추천 배너를 표시한다.
+struct RetrospectFormat {
+ 
+    /// 포맷 고유 식별자
+    let id: UUID
+ 
+    /// 포맷 이름
+    ///
+    /// 예: "KPT", "4Ls", "Start-Stop-Continue"
+    let name: String
+ 
+    /// 포맷에 포함된 카테고리 목록
+    ///
+    /// 순서대로 화면에 표시된다.
+    /// 예: KPT → [Keep, Problem, Try]
+    let categories: [CategoryTemplate]
+ 
+    /// 기본 제공 포맷 여부
+    ///
+    /// `true`이면 삭제/수정 불가.
+    let isBuiltIn: Bool
+ 
+    /// 포맷 설명
+    ///
+    /// 포맷 선택 화면에서 사용자에게 보여줄 한 줄 설명.
+    /// 예: "일상적인 스프린트 회고에 적합"
+    let description: String
+ 
+    /// 추천 조건 설명
+    ///
+    /// 어떤 상황에서 이 포맷을 추천하는지.
+    /// 예: "힘든 스프린트 후 감정 정리가 필요할 때"
+    let recommendWhen: String
+}
+ 
+/// 포맷 내 개별 카테고리를 정의하는 값 객체.
+///
+/// ``RetrospectFormat``의 ``RetrospectFormat/categories``에 포함되며,
+/// 카테고리의 이름, 색상, 표시 순서를 정의한다.
+struct CategoryTemplate {
+ 
+    /// 카테고리 이름
+    ///
+    /// ``RetrospectItem``의 ``RetrospectItem/categoryName``에 저장되는 값.
+    /// 예: "Keep", "Problem", "Liked"
+    let name: String
+ 
+    /// 카테고리 색상 (HEX)
+    ///
+    /// UI에서 카테고리를 시각적으로 구분하는 데 사용한다.
+    /// 예: "#10B981" (Keep 초록), "#F97316" (Problem 주황)
+    let colorHex: String
+ 
+    /// 표시 순서
+    ///
+    /// 0부터 시작. 화면에서 카테고리가 나열되는 순서.
+    let order: Int
+}

--- a/RetroApp/RetroApp/Domain/Entities/RetrospectItem.swift
+++ b/RetroApp/RetroApp/Domain/Entities/RetrospectItem.swift
@@ -17,7 +17,7 @@ import Foundation
 /// 이전 회고의 미해결 Try 항목을 다음 회고로 연결할 수 있다.
 /// - ``linkedTryId``에 원본 Try 항목의 ID를 저장
 /// - ``isResolved``로 해결 여부를 추적
-struct RetrospectItem {
+struct RetrospectItem: Sendable, Equatable, Identifiable {
 
     /// 항목 고유 식별자
     let id: UUID

--- a/RetroApp/RetroApp/Domain/Entities/RetrospectItem.swift
+++ b/RetroApp/RetroApp/Domain/Entities/RetrospectItem.swift
@@ -1,0 +1,57 @@
+//
+//  RetrospectItem.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// 회고 내 개별 항목을 나타내는 Domain Entity.
+///
+/// 하나의 ``Retrospect``에 여러 개의 `RetrospectItem`이 속한다 (1:N).
+/// 카테고리명은 포맷에 따라 달라지며 (Keep, Problem, Liked 등),
+/// String으로 저장하여 어떤 포맷이든 코드 변경 없이 대응한다.
+///
+/// ## Try 이월
+/// 이전 회고의 미해결 Try 항목을 다음 회고로 연결할 수 있다.
+/// - ``linkedTryId``에 원본 Try 항목의 ID를 저장
+/// - ``isResolved``로 해결 여부를 추적
+struct RetrospectItem {
+
+    /// 항목 고유 식별자
+    let id: UUID
+
+    /// 소속 회고의 식별자
+    ///
+    /// ``Retrospect``의 `id`를 참조한다.
+    let retrospectId: UUID
+
+    /// 카테고리명
+    ///
+    /// 포맷에 정의된 카테고리 이름을 그대로 저장한다.
+    /// 예: "Keep", "Problem", "Try", "Liked", "Learned", "Start" 등
+    let categoryName: String
+
+    /// 항목 내용
+    ///
+    /// 사용자가 작성한 텍스트. 빈 문자열은 저장하지 않는다.
+    let content: String
+
+    /// 이월된 원본 Try 항목의 식별자
+    ///
+    /// 이전 회고에서 이월된 항목인 경우, 원본 `RetrospectItem`의 `id`를 참조한다.
+    /// 이월이 아닌 항목이면 `nil`.
+    let linkedTryId: UUID?
+
+    /// Try 항목의 해결 여부
+    ///
+    /// 이월된 Try가 다음 회고에서 "해결됨"으로 처리되면 `true`.
+    /// Try 카테고리가 아닌 항목은 항상 `false`.
+    let isResolved: Bool
+
+    /// 카테고리 내 정렬 순서
+    ///
+    /// 0부터 시작. 드래그로 순서 변경 시 업데이트된다.
+    let order: Int
+}

--- a/RetroApp/RetroApp/Domain/Entities/RetrospectSession.swift
+++ b/RetroApp/RetroApp/Domain/Entities/RetrospectSession.swift
@@ -1,0 +1,88 @@
+//
+//  RetrospectSession.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// 팀 회고 세션을 나타내는 Domain Entity.
+///
+/// 하나의 세션은 팀원들이 동시에 회고를 작성하는 하나의 "모임"이다.
+/// 세션이 시작되면 ``SessionStatus/inProgress``가 되고,
+/// 모든 팀원이 제출하면 ``SessionStatus/completed``로 전환된다.
+///
+/// ## 피어 피드백
+/// ``isAnonymousFeedback``가 `true`이면 해당 세션의 CSS 피어 피드백이 익명으로 처리된다.
+struct RetrospectSession {
+
+    /// 세션 고유 식별자
+    let id: UUID
+
+    /// 소속 팀의 식별자
+    ///
+    /// ``Team``의 `id`를 참조한다.
+    let teamId: UUID
+
+    /// 세션 제목
+    ///
+    /// 예: "Sprint 3 회고", "3월 셋째 주 회고"
+    let title: String
+
+    /// 세션에서 사용하는 회고 포맷의 식별자
+    ///
+    /// ``RetrospectFormat``의 `id`를 참조한다.
+    /// 퍼실리테이터가 세션 시작 시 선택한다.
+    let formatId: UUID
+
+    /// 세션 상태
+    ///
+    /// - ``SessionStatus/inProgress``: 팀원들이 작성 중
+    /// - ``SessionStatus/completed``: 전원 제출 완료
+    let status: SessionStatus
+
+    /// 피어 피드백 익명 여부
+    ///
+    /// `true`이면 CSS 피어 피드백에서 작성자가 표시되지 않는다.
+    /// 퍼실리테이터가 세션 시작 시 설정한다.
+    let isAnonymousFeedback: Bool
+
+    /// 세션 시작 시각
+    let startedAt: Date
+
+    /// 세션 완료 시각
+    ///
+    /// 모든 팀원이 제출하여 세션이 ``SessionStatus/completed``가 된 시점.
+    /// 진행 중이면 `nil`.
+    let completedAt: Date?
+}
+
+/// 팀 회고 세션에서 개별 팀원의 제출 상태를 나타내는 Domain Entity.
+///
+/// 하나의 ``RetrospectSession``에 팀원 수만큼의 `UserSubmission`이 존재한다 (1:N).
+/// 실시간으로 "OO님이 작성 중" 상태를 표시하는 데 사용된다.
+struct UserSubmission {
+
+    /// 제출 상태 고유 식별자
+    let id: UUID
+
+    /// 소속 세션의 식별자
+    ///
+    /// ``RetrospectSession``의 `id`를 참조한다.
+    let sessionId: UUID
+
+    /// 팀원의 사용자 식별자
+    let userId: String
+
+    /// 제출 상태
+    ///
+    /// - ``SubmissionStatus/writing``: 작성 중. typing indicator 표시 가능
+    /// - ``SubmissionStatus/submitted``: 제출 완료. 수정 불가
+    let status: SubmissionStatus
+
+    /// 제출 시각
+    ///
+    /// `status`가 ``SubmissionStatus/submitted``일 때만 값이 있다.
+    let submittedAt: Date?
+}

--- a/RetroApp/RetroApp/Domain/Entities/RetrospectSession.swift
+++ b/RetroApp/RetroApp/Domain/Entities/RetrospectSession.swift
@@ -15,7 +15,7 @@ import Foundation
 ///
 /// ## 피어 피드백
 /// ``isAnonymousFeedback``가 `true`이면 해당 세션의 CSS 피어 피드백이 익명으로 처리된다.
-struct RetrospectSession {
+struct RetrospectSession: Sendable, Equatable, Identifiable {
 
     /// 세션 고유 식별자
     let id: UUID
@@ -62,7 +62,7 @@ struct RetrospectSession {
 ///
 /// 하나의 ``RetrospectSession``에 팀원 수만큼의 `UserSubmission`이 존재한다 (1:N).
 /// 실시간으로 "OO님이 작성 중" 상태를 표시하는 데 사용된다.
-struct UserSubmission {
+struct UserSubmission: Sendable, Equatable, Identifiable {
 
     /// 제출 상태 고유 식별자
     let id: UUID

--- a/RetroApp/RetroApp/Domain/Entities/Team.swift
+++ b/RetroApp/RetroApp/Domain/Entities/Team.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// 팀을 나타내는 Entity
+/// 팀을 나타내는 Domain Entity.
 ///
 /// 팀은 여러 ``TeamMember``와 여러 ``RetrospectSession``을 가진다.
 /// 팀 생성 시 초대 코드가 자동 생성되며, 다른 사용자는 이 코드로 참여할 수 있다.
@@ -15,7 +15,7 @@ import Foundation
 /// ## 인원 제한
 /// - 기본: 2명
 /// - 프리미엄: 10명
-struct Team {
+struct Team: Sendable, Equatable, Identifiable {
 
     /// 팀 고유 식별자
     let id: UUID
@@ -40,7 +40,7 @@ struct Team {
 /// 팀에 소속된 개별 팀원을 나타내는 Domain Entity.
 ///
 /// 하나의 ``Team``에 여러 `TeamMember`가 속한다 (1:N).
-struct TeamMember {
+struct TeamMember: Sendable, Equatable, Identifiable {
 
     /// 팀원 고유 식별자
     let id: UUID
@@ -61,4 +61,3 @@ struct TeamMember {
     /// 팀 참여 시각
     let joinedAt: Date
 }
-

--- a/RetroApp/RetroApp/Domain/Entities/Team.swift
+++ b/RetroApp/RetroApp/Domain/Entities/Team.swift
@@ -1,0 +1,64 @@
+//
+//  Team.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// 팀을 나타내는 Entity
+///
+/// 팀은 여러 ``TeamMember``와 여러 ``RetrospectSession``을 가진다.
+/// 팀 생성 시 초대 코드가 자동 생성되며, 다른 사용자는 이 코드로 참여할 수 있다.
+///
+/// ## 인원 제한
+/// - 기본: 2명
+/// - 프리미엄: 10명
+struct Team {
+
+    /// 팀 고유 식별자
+    let id: UUID
+
+    /// 팀 이름
+    let name: String
+
+    /// 팀 초대 코드
+    ///
+    /// 팀 생성 시 자동 생성. 다른 사용자가 이 코드를 입력하여 팀에 참여한다.
+    let inviteCode: String
+
+    /// 팀 생성자(소유자)의 사용자 식별자
+    ///
+    /// Sign in with Apple에서 발급받은 사용자 ID.
+    let ownerId: String
+
+    /// 팀 생성 시각
+    let createdAt: Date
+}
+
+/// 팀에 소속된 개별 팀원을 나타내는 Domain Entity.
+///
+/// 하나의 ``Team``에 여러 `TeamMember`가 속한다 (1:N).
+struct TeamMember {
+
+    /// 팀원 고유 식별자
+    let id: UUID
+
+    /// 소속 팀의 식별자
+    ///
+    /// ``Team``의 `id`를 참조한다.
+    let teamId: UUID
+
+    /// 사용자 식별자
+    ///
+    /// Sign in with Apple에서 발급받은 사용자 ID.
+    let userId: String
+
+    /// 팀 내 표시 이름
+    let displayName: String
+
+    /// 팀 참여 시각
+    let joinedAt: Date
+}
+


### PR DESCRIPTION
## 📌 관련 이슈
<!-- closes #이슈번호 (머지 시 이슈 자동 닫힘) -->
closes #1

---

## ✨ What's this PR?

### 🧶 주요 변경 내용

Domain 레이어에 핵심 Entity 7개 파일을 정의합니다.

- Retrospect.swift — 회고 Entity
- RetrospectItem.swift — 회고 항목 Entity
- RetrospectFormat.swift — 회고 포맷 + CategoryTemplate Entity
- Enums.swift — 상태/타입 Enum 5종
- Team.swift — 팀 + 팀원 Entity
- RetrospectSession.swift — 팀 회고 세션 + 제출 상태 Entity
- PeerFeedback.swift — CSS 피어 피드백 Entity

---

### 🏗️ 구현 방식

**Domain Entity는 순수 Swift 구조체로 정의했습니다.**

UIKit, Core Data 등 외부 프레임워크에 의존하지 않으며, import Foundation만 사용합니다.

```
Domain Layer 
├── Entities/     ← 순수 Swift struct. 비즈니스 데이터 구조
├── UseCases/     
└── Repositories/
```

Core Data와도 완전히 분리되어 있으며, Data 레이어에서 Mapper를 통해 변환할 예정입니다.


**모든 Entity에 Sendable 프로토콜을 명시적으로 준수합니다.**

```swift
struct Retrospect: Sendable, Equatable, Identifiable { ... }
```
- Sendable: "이 타입은 스레드 간에 안전하게 보낼 수 있는가?"
- Equatable: "이 타입의 두 인스턴스가 같은지 비교할 수 있나?"
- Identifiable: "이 타입을 고유하게 식별할 수 있나?"
- Codable, CaseIterable: JSON 파싱, 전체 케이스를 나열

**다양한 회고 포맷을 지원합니다.**

KPT만 지원하는 게 아니라 4Ls, Start-Stop-Continue 등 다양한 포맷과
사용자 커스텀 포맷까지 코드 변경 없이 대응하도록 설계했습니다.

**Entity 관계 설계**

<img width="1000" alt="Retrospect Session Feedback-2026-03-20-082249" src="https://github.com/user-attachments/assets/876278c0-4c50-4240-a5d8-021fabd0a929" />


---

### 🧪 테스트 / 검증 내역

- [x] 빌드 성공
- [x] Swift 6 경고/에러 없음
- [x] Lint 에러 처리

---

### 💬 기타 공유 사항

(없음)
