### PR TITLE
✨ Feat: Repository Protocol 정의 — Retrospect, Item, Format

### DIFF
--- a/RetroApp/RetroApp/Domain/Repositories/RetrospectFormatRepositoryProtocol.swift
+++ b/RetroApp/RetroApp/Domain/Repositories/RetrospectFormatRepositoryProtocol.swift
@@ -1,0 +1,39 @@
+//
+//  RetrospectFormatRepositoryProtocol.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// 회고 포맷 데이터 접근을 추상화하는 Repository Protocol.
+///
+/// 빌트인 포맷(KPT, 4Ls 등) 조회와 커스텀 포맷 CRUD를 담당한다.
+protocol RetrospectFormatRepositoryProtocol: Sendable {
+
+    /// 전체 포맷 목록을 조회한다.
+    ///
+    /// 빌트인 포맷이 먼저, 커스텀 포맷이 뒤에 오도록 정렬한다.
+    /// - Returns: 포맷 배열
+    func fetchAll() async throws -> [RetrospectFormat]
+
+    /// 특정 포맷을 ID로 조회한다.
+    ///
+    /// - Parameter id: 조회할 포맷의 식별자
+    /// - Returns: 해당 포맷. 없으면 에러
+    func fetchById(_ id: UUID) async throws -> RetrospectFormat
+
+    /// 커스텀 포맷을 저장한다.
+    ///
+    /// `isBuiltIn`은 항상 `false`로 설정된다.
+    /// - Parameter format: 저장할 포맷
+    /// - Returns: 저장된 포맷
+    func save(_ format: RetrospectFormat) async throws -> RetrospectFormat
+
+    /// 커스텀 포맷을 삭제한다.
+    ///
+    /// 빌트인 포맷은 삭제할 수 없다. 시도 시 에러.
+    /// - Parameter id: 삭제할 포맷의 식별자
+    func delete(_ id: UUID) async throws
+}

--- a/RetroApp/RetroApp/Domain/Repositories/RetrospectItemRepositoryProtocol.swift
+++ b/RetroApp/RetroApp/Domain/Repositories/RetrospectItemRepositoryProtocol.swift
@@ -1,0 +1,53 @@
+//
+//  RetrospectItemRepositoryProtocol.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// 회고 항목 데이터 접근을 추상화하는 Repository Protocol.
+///
+/// ``RetrospectItem``의 CRUD와 Try 이월 관련 조회를 담당한다.
+protocol RetrospectItemRepositoryProtocol: Sendable {
+
+    /// 회고 항목을 저장한다.
+    ///
+    /// - Parameter item: 저장할 항목
+    /// - Returns: 저장된 항목
+    func save(_ item: RetrospectItem) async throws -> RetrospectItem
+
+    /// 여러 회고 항목을 일괄 저장한다.
+    ///
+    /// 회고 작성 시 여러 항목을 한번에 저장할 때 사용한다.
+    /// - Parameter items: 저장할 항목 배열
+    /// - Returns: 저장된 항목 배열
+    func saveAll(_ items: [RetrospectItem]) async throws -> [RetrospectItem]
+
+    /// 특정 회고의 항목 목록을 조회한다.
+    ///
+    /// `order` 기준 오름차순으로 정렬하여 반환한다.
+    /// - Parameter retrospectId: 회고 식별자
+    /// - Returns: 항목 배열
+    func fetchByRetrospectId(_ retrospectId: UUID) async throws -> [RetrospectItem]
+
+    /// 회고 항목을 업데이트한다.
+    ///
+    /// 내용 수정, 순서 변경, 해결 여부 변경 시 사용한다.
+    /// - Parameter item: 업데이트할 항목
+    /// - Returns: 업데이트된 항목
+    func update(_ item: RetrospectItem) async throws -> RetrospectItem
+
+    /// 회고 항목을 삭제한다.
+    ///
+    /// - Parameter id: 삭제할 항목의 식별자
+    func delete(_ id: UUID) async throws
+
+    /// 미해결 Try 항목 목록을 조회한다.
+    ///
+    /// 새 회고 작성 시 이월 배너에 표시할 항목을 가져온다.
+    /// 조건: `isResolved == false` && 카테고리가 "Try" 계열
+    /// - Returns: 미해결 Try 항목 배열
+    func fetchUnresolvedTries() async throws -> [RetrospectItem]
+}

--- a/RetroApp/RetroApp/Domain/Repositories/RetrospectRepositoryProtocol.swift
+++ b/RetroApp/RetroApp/Domain/Repositories/RetrospectRepositoryProtocol.swift
@@ -1,0 +1,65 @@
+//
+//  RetrospectRepositoryProtocol.swift
+//  RetroApp
+//
+//  Created by J on 3/20/26.
+//
+
+import Foundation
+
+/// 회고 데이터 접근을 추상화하는 Repository Protocol.
+///
+/// Domain 레이어에서 정의하며, Data 레이어에서 구현체를 제공한다.
+/// UseCase는 이 Protocol에만 의존하고, 실제 저장소(Core Data, API 등)는 알지 못한다.
+///
+/// ## 구현체 예시
+/// - `CoreDataRetrospectRepository`: 로컬 Core Data 저장소
+/// - `RemoteRetrospectRepository`: 서버 API
+protocol RetrospectRepositoryProtocol {
+
+    /// 새 회고를 저장한다.
+    ///
+    /// 드래프트 상태로 생성되며, `id`와 `createdAt`이 자동 할당된다.
+    /// - Parameter retrospect: 저장할 회고
+    /// - Returns: 저장된 회고
+    func save(_ retrospect: Retrospect) async throws -> Retrospect
+
+    /// 전체 회고 목록을 조회한다.
+    ///
+    /// 최신순(createdAt 내림차순)으로 정렬하여 반환한다.
+    /// - Returns: 회고 배열
+    func fetchAll() async throws -> [Retrospect]
+
+    /// 특정 회고를 ID로 조회한다.
+    ///
+    /// - Parameter id: 조회할 회고의 식별자
+    /// - Returns: 해당 회고. 없으면 에러
+    func fetchById(_ id: UUID) async throws -> Retrospect
+
+    /// 특정 날짜의 회고 목록을 조회한다.
+    ///
+    /// 달력 뷰에서 날짜를 탭했을 때 사용한다.
+    /// - Parameter date: 조회할 날짜 (시간 무시, 날짜만 비교)
+    /// - Returns: 해당 날짜의 회고 배열
+    func fetchByDate(_ date: Date) async throws -> [Retrospect]
+
+    /// 회고를 업데이트한다.
+    ///
+    /// 확정 상태에서 수정 시 `isEdited`가 `true`로 변경된다.
+    /// - Parameter retrospect: 업데이트할 회고
+    /// - Returns: 업데이트된 회고
+    func update(_ retrospect: Retrospect) async throws -> Retrospect
+
+    /// 회고를 삭제한다.
+    ///
+    /// 연관된 ``RetrospectItem``도 함께 삭제된다 (cascade).
+    /// - Parameter id: 삭제할 회고의 식별자
+    func delete(_ id: UUID) async throws
+
+    /// 회고가 존재하는 날짜 목록을 조회한다.
+    ///
+    /// 달력 뷰에서 점을 표시하기 위해 사용한다.
+    /// - Parameter month: 조회할 월 (해당 월의 아무 날짜)
+    /// - Returns: 회고가 있는 날짜 배열
+    func fetchDatesWithRetrospect(in month: Date) async throws -> [Date]
+}


### PR DESCRIPTION
## 📌 관련 이슈
closes #3 

---

## ✨ What's this PR?

### 🧶 주요 변경 내용

**추가된 파일:**
- `RetrospectRepositoryProtocol.swift` — 회고 CRUD + 달력 조회
- `RetrospectItemRepositoryProtocol.swift` — 항목 CRUD + 미해결 Try 조회
- `RetrospectFormatRepositoryProtocol.swift` — 포맷 조회 + 커스텀 저장/삭제

---

### 🏗️ 구현 방식

#### async/await 채택

Repository의 반환 타입을 async throws -> T`로 정의했습니다.

```swift
// 채택한 방식
func fetchAll() async throws -> [Retrospect]
```

**이유:**
- Swift 6 기본 비동기 패턴인 async/await가 코드가 더 간결하고 가독성이 높음
- Combine은 아직 학습 전이므로, 추후에 변경해볼 예정

---

### 🧪 테스트 / 검증 내역

- [x] 빌드 성공
- [x] Swift 6 Strict Concurrency 경고/에러 없음

---

### 💬 기타 공유 사항

(없음)