### PR TITLE
✨ Feat: #5 UseCase 정의 (P0 개인 회고)

### DIFF
--- a/RetroApp/RetroApp/Domain/Enums/RetrospectError.swift
+++ b/RetroApp/RetroApp/Domain/Enums/RetrospectError.swift
@@ -1,0 +1,39 @@
+//
+//  RetrospectError.swift
+//  RetroApp
+//
+//  Created by J on 3/26/26.
+//
+
+import Foundation
+
+/// 회고 관련 비즈니스 에러를 나타내는 열거형.
+///
+/// UseCase에서 비즈니스 규칙 위반 시 throw한다.
+enum RetrospectError: LocalizedError, Sendable {
+
+    /// 회고 항목이 0개 일 때 생성/수정/확정 시도
+    case emptyItems
+
+    /// 이미 확정된 회고를 다시 확정 시도
+    case alreadyConfirmed
+
+    /// 요청한 회고를 찾을 수 없음
+    case notFound
+
+    /// 빌트인 포맷을 삭제 시도
+    case cannotDeleteBuiltInFormat
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyItems:
+            return "항목이 최소 1개 이상 필요합니다"
+        case .alreadyConfirmed:
+            return "이미 제출된 회고입니다"
+        case .notFound:
+            return "회고를 찾을 수 없습니다"
+        case .cannotDeleteBuiltInFormat:
+            return "기본 제공 포맷은 삭제할 수 없습니다"
+        }
+    }
+}

--- a/RetroApp/RetroApp/Domain/Repositories/RetrospectRepositoryProtocol.swift
+++ b/RetroApp/RetroApp/Domain/Repositories/RetrospectRepositoryProtocol.swift
@@ -19,7 +19,7 @@ protocol RetrospectRepositoryProtocol {
 
     /// 새 회고를 저장한다.
     ///
-    /// 드래프트 상태로 생성되며, `id`와 `createdAt`이 자동 할당된다.
+    /// 드래프트 상태로 생성되며, `id`와 `createdAt`이 UseCase에서 할당된 상태로 전달된다.
     /// - Parameter retrospect: 저장할 회고
     /// - Returns: 저장된 회고
     func save(_ retrospect: Retrospect) async throws -> Retrospect

--- a/RetroApp/RetroApp/Domain/Usecases/ConfirmRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/ConfirmRetrospectUseCase.swift
@@ -1,0 +1,63 @@
+//
+//  ConfirmRetrospectUseCase.swift
+//  RetroApp
+//
+//  Created by J on 3/26/26.
+//
+
+import Foundation
+
+/// 회고를 확정(제출)하는 UseCase.
+///
+/// ## 비즈니스 규칙
+/// - 드래프트 상태에서만 확정 가능
+/// - 이미 확정된 회고를 다시 확정하면 에러
+/// - 확정 시 `status`가 `.confirmed`, `confirmedAt`에 현재 시각 기록
+/// - 항목이 0개면 확정 불가
+protocol ConfirmRetrospectUseCaseProtocol: Sendable {
+    func execute(id: UUID) async throws -> Retrospect
+}
+
+final class ConfirmRetrospectUseCase: ConfirmRetrospectUseCaseProtocol {
+
+    private let retrospectRepository: RetrospectRepositoryProtocol
+    private let itemRepository: RetrospectItemRepositoryProtocol
+
+    init(
+        retrospectRepository: RetrospectRepositoryProtocol,
+        itemRepository: RetrospectItemRepositoryProtocol
+    ) {
+        self.retrospectRepository = retrospectRepository
+        self.itemRepository = itemRepository
+    }
+
+    func execute(id: UUID) async throws -> Retrospect {
+        let retrospect = try await retrospectRepository.fetchById(id)
+
+        guard retrospect.status == .draft else {
+            throw RetrospectError.alreadyConfirmed
+        }
+
+        let items = try await itemRepository.fetchByRetrospectId(id)
+
+        guard !items.isEmpty else {
+            throw RetrospectError.emptyItems
+        }
+
+        let confirmed = Retrospect(
+            id: retrospect.id,
+            title: retrospect.title,
+            formatId: retrospect.formatId,
+            status: .confirmed,
+            isEdited: false,
+            type: retrospect.type,
+            teamId: retrospect.teamId,
+            sessionId: retrospect.sessionId,
+            timerDuration: retrospect.timerDuration,
+            createdAt: retrospect.createdAt,
+            confirmedAt: Date()
+        )
+
+        return try await retrospectRepository.update(confirmed)
+    }
+}

--- a/RetroApp/RetroApp/Domain/Usecases/CreateRetrospectUseCaseProtocol.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/CreateRetrospectUseCaseProtocol.swift
@@ -71,7 +71,20 @@ final class CreateRetrospectUseCase: CreateRetrospectUseCaseProtocol {
         )
 
         let savedRetrospect = try await retrospectRepository.save(retrospect)
-        _ = try await itemRepository.saveAll(items)
+
+        let itemsWithRetrospectId = items.map { item in
+            RetrospectItem(
+                id: item.id,
+                retrospectId: savedRetrospect.id,
+                categoryName: item.categoryName,
+                content: item.content,
+                linkedTryId: item.linkedTryId,
+                isResolved: item.isResolved,
+                order: item.order
+            )
+        }
+
+        _ = try await itemRepository.saveAll(itemsWithRetrospectId)
 
         return savedRetrospect
     }

--- a/RetroApp/RetroApp/Domain/Usecases/CreateRetrospectUseCaseProtocol.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/CreateRetrospectUseCaseProtocol.swift
@@ -1,0 +1,78 @@
+//
+//  CreateRetrospectUseCaseProtocol.swift
+//  RetroApp
+//
+//  Created by J on 3/23/26.
+//
+
+import Foundation
+
+/// 새 회고를 생성하는 UseCase.
+///
+/// 회고 제목(선택), 포맷, 항목을 받아 드래프트 상태의 회고를 생성한다.
+///
+/// ## 비즈니스 규칙
+/// - 항목이 최소 1개 이상이어야 생성 가능
+/// - 생성 시 `status`는 항상 `.draft`
+/// - `id`와 `createdAt`은 자동 할당
+///
+/// ## 사용 예시
+/// ```swift
+/// let retro = try await createRetrospectUseCase.execute(
+///     title: "Sprint 4 회고",
+///     formatId: kptFormatId,
+///     items: [keepItem, problemItem, tryItem]
+/// )
+/// ```
+protocol CreateRetrospectUseCaseProtocol: Sendable {
+    func execute(
+        title: String?,
+        formatId: UUID,
+        items: [RetrospectItem],
+        timerDuration: Int?
+    ) async throws -> Retrospect
+}
+
+final class CreateRetrospectUseCase: CreateRetrospectUseCaseProtocol {
+
+    private let retrospectRepository: RetrospectRepositoryProtocol
+    private let itemRepository: RetrospectItemRepositoryProtocol
+
+    init(
+        retrospectRepository: RetrospectRepositoryProtocol,
+        itemRepository: RetrospectItemRepositoryProtocol
+    ) {
+        self.retrospectRepository = retrospectRepository
+        self.itemRepository = itemRepository
+    }
+
+    func execute(
+        title: String?,
+        formatId: UUID,
+        items: [RetrospectItem],
+        timerDuration: Int?
+    ) async throws -> Retrospect {
+        guard !items.isEmpty else {
+            throw RetrospectError.emptyItems
+        }
+
+        let retrospect = Retrospect(
+            id: UUID(),
+            title: title,
+            formatId: formatId,
+            status: .draft,
+            isEdited: false,
+            type: .personal,
+            teamId: nil,
+            sessionId: nil,
+            timerDuration: timerDuration,
+            createdAt: Date(),
+            confirmedAt: nil
+        )
+
+        let savedRetrospect = try await retrospectRepository.save(retrospect)
+        _ = try await itemRepository.saveAll(items)
+
+        return savedRetrospect
+    }
+}

--- a/RetroApp/RetroApp/Domain/Usecases/DeleteRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/DeleteRetrospectUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  DeleteRetrospectUseCase.swift
+//  RetroApp
+//
+//  Created by J on 3/26/26.
+//
+
+import Foundation
+
+/// 회고를 삭제하는 UseCase.
+///
+/// ## 비즈니스 규칙
+/// - 드래프트/확정 모두 삭제 가능
+/// - 연관된 ``RetrospectItem``도 함께 삭제됨 (Repository에서 cascade 처리)
+protocol DeleteRetrospectUseCaseProtocol: Sendable {
+    func execute(id: UUID) async throws
+}
+
+final class DeleteRetrospectUseCase: DeleteRetrospectUseCaseProtocol {
+
+    private let repository: RetrospectRepositoryProtocol
+
+    init(repository: RetrospectRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(id: UUID) async throws {
+        try await repository.delete(id)
+    }
+}

--- a/RetroApp/RetroApp/Domain/Usecases/FetchRetrospectByDateUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/FetchRetrospectByDateUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  FetchRetrospectByDateUseCase.swift
+//  RetroApp
+//
+//  Created by J on 3/26/26.
+//
+
+import Foundation
+
+/// 특정 날짜의 회고를 조회하는 UseCase.
+///
+/// 달력 뷰에서 날짜를 탭했을 때 사용한다.
+protocol FetchRetrospectByDateUseCaseProtocol: Sendable {
+    func execute(date: Date) async throws -> [Retrospect]
+}
+
+final class FetchRetrospectByDateUseCase: FetchRetrospectByDateUseCaseProtocol {
+
+    private let repository: RetrospectRepositoryProtocol
+
+    init(repository: RetrospectRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(date: Date) async throws -> [Retrospect] {
+        try await repository.fetchByDate(date)
+    }
+}

--- a/RetroApp/RetroApp/Domain/Usecases/FetchRetrospectFormatsUseCaseProtocol.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/FetchRetrospectFormatsUseCaseProtocol.swift
@@ -1,0 +1,29 @@
+//
+//  FetchRetrospectFormatsUseCaseProtocol.swift
+//  RetroApp
+//
+//  Created by J on 3/26/26.
+//
+
+import Foundation
+
+/// 회고 포맷 목록을 조회하는 UseCase.
+///
+/// 포맷 선택 화면에서 사용한다.
+/// 빌트인 포맷이 먼저, 커스텀 포맷이 뒤에 오도록 정렬한다.
+protocol FetchRetrospectFormatsUseCaseProtocol: Sendable {
+    func execute() async throws -> [RetrospectFormat]
+}
+
+final class FetchRetrospectFormatsUseCase: FetchRetrospectFormatsUseCaseProtocol {
+
+    private let repository: RetrospectFormatRepositoryProtocol
+
+    init(repository: RetrospectFormatRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute() async throws -> [RetrospectFormat] {
+        try await repository.fetchAll()
+    }
+}

--- a/RetroApp/RetroApp/Domain/Usecases/FetchRetrospectListUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/FetchRetrospectListUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  FetchRetrospectListUseCase.swift
+//  RetroApp
+//
+//  Created by J on 3/23/26.
+//
+
+import Foundation
+
+/// 전체 회고 목록을 조회하는 UseCase.
+///
+/// 최신순으로 정렬된 회고 배열을 반환한다.
+/// 리스트 뷰에서 사용한다.
+protocol FetchRetrospectListUseCaseProtocol: Sendable {
+    func execute() async throws -> [Retrospect]
+}
+
+final class FetchRetrospectListUseCase: FetchRetrospectListUseCaseProtocol {
+
+    private let repository: RetrospectRepositoryProtocol
+
+    init(repository: RetrospectRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute() async throws -> [Retrospect] {
+        try await repository.fetchAll()
+    }
+}

--- a/RetroApp/RetroApp/Domain/Usecases/FetchUnresolvedTriesUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/FetchUnresolvedTriesUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  FetchUnresolvedTriesUseCase.swift
+//  RetroApp
+//
+//  Created by J on 3/26/26.
+//
+
+import Foundation
+
+/// 미해결 Try 항목을 조회하는 UseCase.
+///
+/// 새 회고 작성 시 이월 배너에 표시할 미해결 Try 목록을 가져온다.
+/// "해결됨" 또는 "이월" 선택의 기반 데이터가 된다.
+protocol FetchUnresolvedTriesUseCaseProtocol: Sendable {
+    func execute() async throws -> [RetrospectItem]
+}
+
+final class FetchUnresolvedTriesUseCase: FetchUnresolvedTriesUseCaseProtocol {
+
+    private let repository: RetrospectItemRepositoryProtocol
+
+    init(repository: RetrospectItemRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute() async throws -> [RetrospectItem] {
+        try await repository.fetchUnresolvedTries()
+    }
+}
+

--- a/RetroApp/RetroApp/Domain/Usecases/FetchUnresolvedTriesUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/FetchUnresolvedTriesUseCase.swift
@@ -27,4 +27,3 @@ final class FetchUnresolvedTriesUseCase: FetchUnresolvedTriesUseCaseProtocol {
         try await repository.fetchUnresolvedTries()
     }
 }
-

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -1,0 +1,68 @@
+//
+//  UpdateRetrospectUseCase.swift
+//  RetroApp
+//
+//  Created by J on 3/26/26.
+//
+
+import Foundation
+
+/// 회고를 수정하는 UseCase.
+///
+/// ## 비즈니스 규칙
+/// - 드래프트 상태: 자유롭게 수정 가능
+/// - 확정 상태: 수정 가능하지만 `isEdited`가 `true`로 변경됨
+/// - 항목이 0개가 되면 수정 불가
+protocol UpdateRetrospectUseCaseProtocol: Sendable {
+    func execute(
+        _ retrospect: Retrospect,
+        items: [RetrospectItem]
+    ) async throws -> Retrospect
+}
+
+final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
+
+    private let retrospectRepository: RetrospectRepositoryProtocol
+    private let itemRepository: RetrospectItemRepositoryProtocol
+
+    init(
+        retrospectRepository: RetrospectRepositoryProtocol,
+        itemRepository: RetrospectItemRepositoryProtocol) {
+        self.retrospectRepository = retrospectRepository
+        self.itemRepository = itemRepository
+    }
+
+    func execute(
+        _ retrospect: Retrospect,
+        items: [RetrospectItem]
+    ) async throws -> Retrospect {
+        guard !items.isEmpty else {
+            throw RetrospectError.emptyItems
+        }
+
+        var updated = retrospect
+
+        if retrospect.status == .confirmed {
+            updated = Retrospect(
+                id: retrospect.id,
+                title: retrospect.title,
+                formatId: retrospect.formatId,
+                status: retrospect.status,
+                isEdited: true,
+                type: retrospect.type,
+                teamId: retrospect.teamId,
+                sessionId: retrospect.sessionId,
+                timerDuration: retrospect.timerDuration,
+                createdAt: retrospect.createdAt,
+                confirmedAt: retrospect.confirmedAt
+            )
+        }
+
+        let savedRetrospect = try await retrospectRepository.update(updated)
+
+        _ = try await itemRepository.saveAll(items)
+
+        return savedRetrospect
+
+    }
+}

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -40,7 +40,7 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
             throw RetrospectError.emptyItems
         }
 
-        var updated = retrospect
+        let updated: Retrospect
 
         if retrospect.status == .confirmed {
             updated = Retrospect(
@@ -49,6 +49,20 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
                 formatId: retrospect.formatId,
                 status: retrospect.status,
                 isEdited: true,
+                type: retrospect.type,
+                teamId: retrospect.teamId,
+                sessionId: retrospect.sessionId,
+                timerDuration: retrospect.timerDuration,
+                createdAt: retrospect.createdAt,
+                confirmedAt: retrospect.confirmedAt
+            )
+        } else {
+            updated = Retrospect(
+                id: retrospect.id,
+                title: retrospect.title,
+                formatId: retrospect.formatId,
+                status: retrospect.status,
+                isEdited: false,
                 type: retrospect.type,
                 teamId: retrospect.teamId,
                 sessionId: retrospect.sessionId,


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈
<!-- closes #이슈번호 (머지 시 이슈 자동 닫힘) -->
closes #5

---

## ✨ What's this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

Domain 레이어에 UseCase 8개와 Error 타입 1개를 정의합니다.
각 UseCase는 하나의 비즈니스 행위만 담당하며, Repository Protocol을 주입받아 데이터에 접근합니다.

**추가된 파일 (Domain/UseCases/):**
- `CreateRetrospectUseCase.swift` — 회고 생성 (드래프트)
- `FetchRetrospectListUseCase.swift` — 전체 목록 조회
- `FetchRetrospectByDateUseCase.swift` — 날짜별 조회 (달력 뷰)
- `UpdateRetrospectUseCase.swift` — 회고 수정
- `DeleteRetrospectUseCase.swift` — 회고 삭제
- `ConfirmRetrospectUseCase.swift` — 회고 확정 (드래프트 → 확정)
- `FetchUnresolvedTriesUseCase.swift` — 미해결 Try 조회 (이월 배너)
- `FetchRetrospectFormatsUseCase.swift` — 포맷 목록 조회

**추가된 파일 (Domain/Enums/):**
- `RetrospectError.swift` — 비즈니스 에러 타입

---

### 🏗️ 구현 방식
<!-- 핵심 기술적 결정, 아키텍처 선택 이유, 사용한 패턴 등 -->

#### Protocol + 구현체 분리

모든 UseCase를 Protocol과 구현체로 분리했습니다.
ViewModel은 Protocol에만 의존하므로, 테스트 시 Mock으로 교체할 수 있습니다.
```swift
protocol FetchRetrospectListUseCaseProtocol: Sendable {
    func execute() async throws -> [Retrospect]
}

final class FetchRetrospectListUseCase: FetchRetrospectListUseCaseProtocol { ... }
```

#### 단일 책임 원칙

각 UseCase가 하나의 비즈니스 행위만 담당합니다.

| UseCase | 책임 |
| --- | --- |
| Create | 항목 검증 → 드래프트 생성 → 회고 + 항목 저장 |
| FetchList | 전체 목록 조회 |
| FetchByDate | 특정 날짜 회고 조회 |
| Update | 확정 상태면 isEdited 처리 → 회고 + 항목 업데이트 |
| Delete | 삭제 (cascade) |
| Confirm | 드래프트 검증 → 항목 검증 → 확정 처리 |
| FetchUnresolvedTries | 미해결 Try 목록 조회 |
| FetchFormats | 포맷 목록 조회 |

#### 비즈니스 규칙 검증

UseCase 내에서 비즈니스 규칙을 검증하고, 위반 시 `RetrospectError`를 throw합니다.
```swift
// CreateRetrospectUseCase — 항목 0개면 생성 불가
guard !items.isEmpty else {
    throw RetrospectError.emptyItems
}

// ConfirmRetrospectUseCase — 이미 확정이면 에러
guard retrospect.status == .draft else {
    throw RetrospectError.alreadyConfirmed
}

// UpdateRetrospectUseCase — 확정 상태 수정 시 isEdited 처리
if retrospect.status == .confirmed {
    updated = Retrospect(..., isEdited: true, ...)
}
```

#### RetrospectError

`LocalizedError`를 준수하여 `errorDescription`으로 사용자 메시지를 제공합니다.

| 케이스 | 발생 조건 |
| --- | --- |
| `emptyItems` | 항목 0개로 생성/수정/확정 시도 |
| `alreadyConfirmed` | 확정된 회고 재확정 시도 |
| `notFound` | 존재하지 않는 회고 접근 |
| `cannotDeleteBuiltInFormat` | 빌트인 포맷 삭제 시도 |

---

### 📸 스크린샷 
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

(없음)

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 성공
- [x] Domain 레이어에 Foundation 외 import 없음 확인
- [x] 모든 UseCase Protocol에 Sendable 준수

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 다음 PR에서 Data 레이어(Core Data 스키마, Repository 구현체)를 진행합니다.
- 팀 관련 UseCase(세션, 피어 피드백)는 P1에서 추가합니다.
