### PR TITLE
✨ Feature: #7 Data 레이어 구현 (Core Data 스키마 + Stack + Mapper + Repository)

### DIFF
--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -1,0 +1,76 @@
+//
+//  CoreDataStack.swift
+//  RetroApp
+//
+//  Created by J on 3/26/26.
+//
+
+import CoreData
+import Foundation
+
+/// Core Data 스택을 관리하는 클래스.
+///
+/// 앱 전체에서 하나의 인스턴스만 사용한다.
+/// `viewContext`는 메인 스레드에서, `backgroundContext`는 백그라운드에서 사용한다.
+///
+/// ## Data 레이어 소속
+/// Domain 레이어는 이 클래스를 알지 못한다.
+/// Repository 구현체에서만 사용한다.
+final class CoreDataStack {
+
+    // MARK: - Properties
+
+    /// Core Data 컨테이너
+    ///
+    /// "RetroApp"은 .xcdatamodeld 파일 이름과 동일해야 한다.
+    private let container: NSPersistentContainer
+
+    /// 메인 스레드용 Context
+    ///
+    /// UI에서 데이터를 읽을 때 사용한다.
+    /// 항상 메인 스레드에서만 접근해야 한다.
+    var viewContext: NSManagedObjectContext {
+        container.viewContext
+    }
+
+    // MARK: - Init
+
+    /// CoreDataStack을 초기화한다.
+    ///
+    /// - Parameter modelName: .xcdatamodeld 파일 이름. 기본값 "RetroApp"
+    init(modelName: String = "RetroApp") {
+        container = NSPersistentContainer(name: modelName)
+
+        // SQLite 파일을 열어서 준비하는 과정
+        container.loadPersistentStores { _, error in
+            if let error {
+                fatalError("Core Data 로드 실패: \(error)")
+            }
+        }
+
+        // 백그라운드에서 저장하면 viewContext에 자동 반영
+        container.viewContext.automaticallyMergesChangesFromParent = true
+
+        // 같은 객체를 중복 생성하지 않고 기존 객체를 재사용
+        container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+    }
+
+    // MARK: - Methods
+
+    /// 백그라운드 작업용 Context를 생성한다.
+    ///
+    /// 무거운 저장/조회 작업을 메인 스레드를 막지 않고 처리할 때 사용한다.
+    /// 사용 후 `save()`를 호출해야 반영된다.
+    func newBackgroundContext() -> NSManagedObjectContext {
+        container.newBackgroundContext()
+    }
+
+    /// Context의 변경사항을 저장한다.
+    ///
+    /// 변경사항이 없으면 아무것도 하지 않는다.
+    /// - Parameter context: 저장할 Context
+    func saveContext(_ context: NSManagedObjectContext) throws {
+        guard context.hasChanges else { return }
+        try context.save()
+    }
+}

--- a/RetroApp/RetroApp/Data/Mapper/RetrospectFormatMapper.swift
+++ b/RetroApp/RetroApp/Data/Mapper/RetrospectFormatMapper.swift
@@ -1,0 +1,101 @@
+//
+//  RetrospectFormatMapper.swift
+//  RetroApp
+//
+//  Created by J on 3/30/26.
+//
+
+import CoreData
+import Foundation
+
+/// ``RetrospectFormat`` Domain Entity와 Core Data ManagedObject 간 변환을 담당하는 Mapper.
+///
+/// ## categories 변환
+/// `[CategoryTemplate]`은 Core Data에 직접 저장할 수 없으므로,
+/// JSON 문자열로 인코딩하여 `categoriesJSON` Attribute에 저장한다.
+enum RetrospectFormatMapper {
+
+    // MARK: - ManagedObject → Domain Entity
+
+    static func toEntity(_ managed: RetrospectFormatEntity) -> RetrospectFormat {
+        let categories = decodeCategories(from: managed.categoriesJSON ?? "[]")
+
+        return RetrospectFormat(
+            id: managed.id ?? UUID(),
+            name: managed.name ?? "",
+            categories: categories,
+            isBuiltIn: managed.isBuiltIn,
+            description: managed.descriptionText ?? "",
+            recommendWhen: managed.recommendWhen ?? ""
+        )
+    }
+
+    // MARK: - Domain Entity → ManagedObject
+
+    static func toManagedObject(
+        _ entity: RetrospectFormat,
+        context: NSManagedObjectContext
+    ) -> RetrospectFormatEntity {
+        let managed = RetrospectFormatEntity(context: context)
+        managed.id = entity.id
+        managed.name = entity.name
+        managed.categoriesJSON = encodeCategories(entity.categories)
+        managed.isBuiltIn = entity.isBuiltIn
+        managed.descriptionText = entity.description
+        managed.recommendWhen = entity.recommendWhen
+        return managed
+    }
+
+    // MARK: - Domain Entity → 기존 ManagedObject 업데이트
+
+    static func update(_ managed: RetrospectFormatEntity, from entity: RetrospectFormat) {
+        managed.name = entity.name
+        managed.categoriesJSON = encodeCategories(entity.categories)
+        managed.isBuiltIn = entity.isBuiltIn
+        managed.descriptionText = entity.description
+        managed.recommendWhen = entity.recommendWhen
+    }
+
+    // MARK: - JSON 변환 헬퍼
+
+    /// [CategoryTemplate] → JSON 문자열
+    private static func encodeCategories(_ categories: [CategoryTemplate]) -> String {
+        let dicts = categories.map { category in
+            [
+                "name": category.name,
+                "colorHex": category.colorHex,
+                "order": "\(category.order)"
+            ]
+        }
+
+        guard let data = try? JSONSerialization.data(withJSONObject: dicts),
+              let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+
+        return json
+    }
+
+    /// JSON 문자열 → [CategoryTemplate]
+    private static func decodeCategories(from json: String) -> [CategoryTemplate] {
+        guard let data = json.data(using: .utf8),
+              let dicts = try? JSONSerialization.jsonObject(with: data) as? [[String: String]] else {
+            return []
+        }
+
+        return dicts.compactMap { dict in
+            guard let name = dict["name"],
+                  let colorHex = dict["colorHex"],
+                  let orderString = dict["order"],
+                  let order = Int(orderString) else {
+                return nil
+            }
+
+            return CategoryTemplate(
+                name: name,
+                colorHex: colorHex,
+                order: order
+            )
+        }
+    }
+}

--- a/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
+++ b/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
@@ -1,0 +1,56 @@
+//
+//  RetrospectItemMapper.swift
+//  RetroApp
+//
+//  Created by J on 3/29/26.
+//
+
+import CoreData
+import Foundation
+
+/// ``RetrospectItem`` Domain Entity와 Core Data ManagedObject 간 변환을 담당하는 Mapper.
+enum RetrospectItemMapper {
+
+    // MARK: - ManagedObject → Domain Entity
+
+    static func toEntity(_ managed: RetrospectItemEntity) -> RetrospectItem {
+        RetrospectItem(
+            id: managed.id ?? UUID(),
+            retrospectId: managed.retrospectId ?? UUID(),
+            categoryName: managed.categoryName ?? "",
+            content: managed.content ?? "",
+            linkedTryId: managed.linkedTryId,
+            isResolved: managed.isResolved,
+            order: Int(managed.order)
+        )
+    }
+
+    // MARK: - Domain Entity → ManagedObject
+
+    static func toManagedObject(
+        _ entity: RetrospectItem,
+        context: NSManagedObjectContext,
+    ) -> RetrospectItemEntity {
+        let managed = RetrospectItemEntity(context: context)
+
+        managed.id = entity.id
+        managed.retrospectId = entity.retrospectId
+        managed.categoryName = entity.categoryName
+        managed.content = entity.content
+        managed.linkedTryId = entity.linkedTryId
+        managed.isResolved = entity.isResolved
+        managed.order = Int32(entity.order)
+        return managed
+    }
+
+    // MARK: - Domain Entity → 기존 ManagedObject 업데이트
+
+    static func update(_ managed: RetrospectItemEntity, from entity: RetrospectItem) {
+        managed.retrospectId = entity.retrospectId
+        managed.categoryName = entity.categoryName
+        managed.content = entity.content
+        managed.linkedTryId = entity.linkedTryId
+        managed.isResolved = entity.isResolved
+        managed.order = Int32(entity.order)
+    }
+}

--- a/RetroApp/RetroApp/Data/Mapper/RetrospectMapper.swift
+++ b/RetroApp/RetroApp/Data/Mapper/RetrospectMapper.swift
@@ -29,11 +29,12 @@ enum RetrospectMapper {
             status: RetrospectStatus(rawValue: managed.status ?? "") ?? .draft,
             isEdited: managed.isEdited,
             type: RetrospectType(rawValue: managed.type ?? "") ?? .personal,
-            teamId: managed.teamId ?? UUID(),
-            sessionId: managed.sessionId ?? UUID(),
+            teamId: managed.teamId,
+            sessionId: managed.sessionId,
             timerDuration: managed.timerDuration == 0 ? nil : Int(managed.timerDuration),
             createdAt: managed.createdAt ?? Date(),
-            confirmedAt: managed.confirmedAt ?? Date())
+            confirmedAt: managed.confirmedAt
+        )
     }
 
     // MARK: - Domain Entity → ManagedObject

--- a/RetroApp/RetroApp/Data/Mapper/RetrospectMapper.swift
+++ b/RetroApp/RetroApp/Data/Mapper/RetrospectMapper.swift
@@ -1,0 +1,85 @@
+//
+//  RetrospectMapper.swift
+//  RetroApp
+//
+//  Created by J on 3/26/26.
+//
+
+import CoreData
+import Foundation
+
+/// ``Retrospect`` Domain Entity와 Core Data ManagedObject 간 변환을 담당하는 Mapper.
+///
+/// Data 레이어에서만 사용한다.
+/// Domain 레이어는 ManagedObject의 존재를 알지 못한다.
+enum RetrospectMapper {
+
+    // MARK: - ManagedObject → Domain Entity
+
+    /// Core Data의 `RetrospectEntity`를 Domain의 ``Retrospect``로 변환한다.
+    ///
+    /// ManagedObject의 Optional 프로퍼티는 기본값으로 처리한다.
+    /// - Parameter managed: 변환할 ManagedObject
+    /// - Returns: Domain Entity
+    static func toEntity(_ managed: RetrospectEntity) -> Retrospect {
+        return Retrospect(
+            id: managed.id ?? UUID(),
+            title: managed.title,
+            formatId: managed.formatId ?? UUID(),
+            status: RetrospectStatus(rawValue: managed.status ?? "") ?? .draft,
+            isEdited: managed.isEdited,
+            type: RetrospectType(rawValue: managed.type ?? "") ?? .personal,
+            teamId: managed.teamId ?? UUID(),
+            sessionId: managed.sessionId ?? UUID(),
+            timerDuration: managed.timerDuration == 0 ? nil : Int(managed.timerDuration),
+            createdAt: managed.createdAt ?? Date(),
+            confirmedAt: managed.confirmedAt ?? Date())
+    }
+
+    // MARK: - Domain Entity → ManagedObject
+
+    /// Domain의 ``Retrospect``를 Core Data의 `RetrospectEntity`로 변환한다.
+    ///
+    /// 새 ManagedObject를 생성하여 프로퍼티를 채운다.
+    /// - Parameters:
+    ///   - entity: 변환할 Domain Entity
+    ///   - context: ManagedObject를 생성할 Core Data Context
+    /// - Returns: 생성된 ManagedObject
+    static func toManagedObject(_ entity: Retrospect, context: NSManagedObjectContext) -> RetrospectEntity {
+        let managed = RetrospectEntity(context: context)
+        managed.id = entity.id
+        managed.title = entity.title
+        managed.formatId = entity.formatId
+        managed.status = entity.status.rawValue
+        managed.isEdited = entity.isEdited
+        managed.type = entity.type.rawValue
+        managed.teamId = entity.teamId
+        managed.sessionId = entity.sessionId
+        managed.timerDuration = Int32(entity.timerDuration ?? 0)
+        managed.createdAt = entity.createdAt
+        managed.confirmedAt = entity.confirmedAt
+        return managed
+    }
+
+    // MARK: - Domain Entity → 기존 ManagedObject 업데이트
+
+    /// 기존 ManagedObject에 Domain Entity의 값을 덮어쓴다.
+    ///
+    /// 새 ManagedObject를 생성하지 않고 기존 객체를 업데이트할 때 사용한다.
+    /// Repository의 `update` 메서드에서 활용된다.
+    /// - Parameters:
+    ///   - managed: 업데이트할 기존 ManagedObject
+    ///   - entity: 새 값을 가진 Domain Entity
+    static func update(_ managed: RetrospectEntity, from entity: Retrospect) {
+        managed.title = entity.title
+        managed.formatId = entity.formatId
+        managed.status = entity.status.rawValue
+        managed.isEdited = entity.isEdited
+        managed.type = entity.type.rawValue
+        managed.teamId = entity.teamId
+        managed.sessionId = entity.sessionId
+        managed.timerDuration = Int32(entity.timerDuration ?? 0)
+        managed.createdAt = entity.createdAt
+        managed.confirmedAt = entity.confirmedAt
+    }
+}

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
@@ -75,7 +75,9 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
     /// - Parameter format: 저장할 포맷
     /// - Returns: 저장된 포맷
     func save(_ format: RetrospectFormat) async throws -> RetrospectFormat {
-        _ = RetrospectFormatMapper.toManagedObject(format, context: coreDataStack.viewContext)
+        let managed = RetrospectFormatMapper.toManagedObject(format, context: coreDataStack.viewContext)
+        managed.isBuiltIn = false
+        
         try coreDataStack.saveContext(coreDataStack.viewContext)
         return format
     }

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
@@ -34,7 +34,7 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
         let request = NSFetchRequest<RetrospectFormatEntity>(entityName: "RetrospectFormatEntity")
         request.sortDescriptors = [
             NSSortDescriptor(key: "isBuiltIn", ascending: false),
-            NSSortDescriptor(key: "name", ascending: true),
+            NSSortDescriptor(key: "name", ascending: true)
         ]
 
         do {

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
@@ -1,0 +1,112 @@
+//
+//  CoreDataRetrospectFormatRepository.swift
+//  RetroApp
+//
+//  Created by J on 3/30/26.
+//
+
+import CoreData
+import Foundation
+
+/// ``RetrospectFormatRepositoryProtocol``의 Core Data 구현체.
+///
+/// 빌트인 포맷(KPT, 4Ls 등) 조회와 커스텀 포맷 저장/삭제를 담당한다.
+/// ``RetrospectFormatMapper``를 통해 ManagedObject와 Domain Entity 간 변환을 수행한다.
+final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtocol {
+    // MARK: - Properties
+
+    private let coreDataStack: CoreDataStack
+
+    // MARK: - Init
+
+    init(coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
+    }
+
+    // MARK: - Read
+
+    /// 전체 포맷 목록을 조회한다.
+    ///
+    /// 빌트인 포맷이 먼저, 커스텀 포맷이 뒤에 오도록 정렬한다.
+    /// 같은 그룹 내에서는 이름 오름차순으로 정렬한다.
+    /// - Returns: 포맷 배열
+    func fetchAll() async throws -> [RetrospectFormat] {
+        let request = NSFetchRequest<RetrospectFormatEntity>(entityName: "RetrospectFormatEntity")
+        request.sortDescriptors = [
+            NSSortDescriptor(key: "isBuiltIn", ascending: false),
+            NSSortDescriptor(key: "name", ascending: true),
+        ]
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+            return response.map { RetrospectFormatMapper.toEntity($0) }
+        } catch {
+            throw error
+        }
+    }
+
+    /// 특정 포맷을 ID로 조회한다.
+    ///
+    /// - Parameter id: 조회할 포맷의 식별자
+    /// - Returns: 해당 포맷
+    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 포맷이 없을 때
+    func fetchById(_ id: UUID) async throws -> RetrospectFormat {
+        let request = NSFetchRequest<RetrospectFormatEntity>(entityName: "RetrospectFormatEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+
+            guard let managed = response.first else {
+                throw RetrospectError.notFound
+            }
+
+            return RetrospectFormatMapper.toEntity(managed)
+        } catch {
+            throw error
+        }
+    }
+
+    // MARK: - Create
+
+    /// 커스텀 포맷을 Core Data에 저장한다.
+    ///
+    /// `isBuiltIn`은 항상 `false`로 설정된다.
+    /// - Parameter format: 저장할 포맷
+    /// - Returns: 저장된 포맷
+    func save(_ format: RetrospectFormat) async throws -> RetrospectFormat {
+        _ = RetrospectFormatMapper.toManagedObject(format, context: coreDataStack.viewContext)
+        try coreDataStack.saveContext(coreDataStack.viewContext)
+        return format
+    }
+
+    // MARK: - Delete
+
+    /// 커스텀 포맷을 삭제한다.
+    ///
+    /// 빌트인 포맷은 삭제할 수 없다. 시도 시 ``RetrospectError/cannotDeleteBuiltInFormat`` 에러.
+    /// - Parameter id: 삭제할 포맷의 식별자
+    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 포맷이 없을 때
+    /// - Throws: ``RetrospectError/cannotDeleteBuiltInFormat`` — 빌트인 포맷 삭제 시도 시
+    func delete(_ id: UUID) async throws {
+        let request = NSFetchRequest<RetrospectFormatEntity>(entityName: "RetrospectFormatEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+
+            guard let managed = response.first else {
+                throw RetrospectError.notFound
+            }
+
+            guard !managed.isBuiltIn else {
+                throw RetrospectError.cannotDeleteBuiltInFormat
+            }
+
+            coreDataStack.viewContext.delete(managed)
+            try coreDataStack.saveContext(coreDataStack.viewContext)
+        } catch {
+            throw error
+        }
+    }
+}

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
@@ -58,7 +58,7 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
             let response = try coreDataStack.viewContext.fetch(request)
 
             guard let managed = response.first else {
-                throw RetrospectError.notFound
+                throw RetrospectError.formatNotFound
             }
 
             return RetrospectFormatMapper.toEntity(managed)
@@ -96,7 +96,7 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
             let response = try coreDataStack.viewContext.fetch(request)
 
             guard let managed = response.first else {
-                throw RetrospectError.notFound
+                throw RetrospectError.formatNotFound
             }
 
             guard !managed.isBuiltIn else {

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -1,0 +1,142 @@
+//
+//  CoreDataRetrospectItemRepository.swift
+//  RetroApp
+//
+//  Created by J on 3/30/26.
+//
+
+import CoreData
+import Foundation
+
+/// ``RetrospectItemRepositoryProtocol``의 Core Data 구현체.
+///
+/// Domain 레이어의 ``RetrospectItem`` Entity를 Core Data로 저장/조회/수정/삭제한다.
+/// ``RetrospectItemMapper``를 통해 ManagedObject와 Domain Entity 간 변환을 수행한다.
+final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
+
+    // MARK: - Properties
+
+    private let coreDataStack: CoreDataStack
+
+    // MARK: - Init
+
+    init(coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
+    }
+
+    // MARK: - Create
+
+    /// 회고 항목을 Core Data에 저장한다.
+    ///
+    /// - Parameter item: 저장할 항목
+    /// - Returns: 저장된 항목
+    func save(_ item: RetrospectItem) async throws -> RetrospectItem {
+        _ = RetrospectItemMapper.toManagedObject(item, context: coreDataStack.viewContext)
+        try coreDataStack.saveContext(coreDataStack.viewContext)
+        return item
+    }
+
+    /// 여러 회고 항목을 일괄 저장한다.
+    ///
+    /// 모든 항목을 context에 추가한 뒤 `save()`를 한 번만 호출하여
+    /// 트랜잭션 효율을 높인다.
+    /// - Parameter items: 저장할 항목 배열
+    /// - Returns: 저장된 항목 배열
+    func saveAll(_ items: [RetrospectItem]) async throws -> [RetrospectItem] {
+        for item in items {
+            _ = RetrospectItemMapper.toManagedObject(item, context: coreDataStack.viewContext)
+        }
+
+        try coreDataStack.saveContext(coreDataStack.viewContext)
+        return items
+    }
+
+    // MARK: - Read
+
+    /// 특정 회고의 항목 목록을 조회한다.
+    ///
+    /// `order` 오름차순으로 정렬하여 반환한다.
+    /// - Parameter retrospectId: 회고 식별자
+    /// - Returns: 항목 배열
+    func fetchByRetrospectId(_ retrospectId: UUID) async throws -> [RetrospectItem] {
+        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
+        request.predicate = NSPredicate(format: "retrospectId == %@", retrospectId as CVarArg)
+        request.sortDescriptors = [NSSortDescriptor(key: "order", ascending: true)]
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+            return response.map { RetrospectItemMapper.toEntity($0) }
+        } catch {
+            throw error
+        }
+    }
+
+    /// 미해결 Try 항목 목록을 조회한다.
+    ///
+    /// 새 회고 작성 시 이월 배너에 표시할 항목을 가져온다.
+    /// 조건: `isResolved == false`
+    /// - Returns: 미해결 Try 항목 배열
+    func fetchUnresolvedTries() async throws -> [RetrospectItem] {
+        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
+        request.predicate = NSPredicate(format: "isResolved == NO")
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+            return response.map { RetrospectItemMapper.toEntity($0) }
+        } catch {
+            throw error
+        }
+    }
+
+    // MARK: - Update
+
+    /// 회고 항목을 업데이트한다.
+    ///
+    /// ID로 기존 ManagedObject를 찾아 ``RetrospectItemMapper``로 값을 덮어쓴다.
+    /// - Parameter item: 업데이트할 항목
+    /// - Returns: 업데이트된 항목
+    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 항목이 없을 때
+    func update(_ item: RetrospectItem) async throws -> RetrospectItem {
+        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
+        request.predicate = NSPredicate(format: "id == %@", item.id as CVarArg)
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+
+            guard let managed = response.first else {
+                throw RetrospectError.notFound
+            }
+
+            RetrospectItemMapper.update(managed, from: item)
+            try coreDataStack.saveContext(coreDataStack.viewContext)
+
+            return item
+        } catch {
+            throw error
+        }
+    }
+
+    // MARK: - Delete
+
+    /// 회고 항목을 삭제한다.
+    ///
+    /// - Parameter id: 삭제할 항목의 식별자
+    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 항목이 없을 때
+    func delete(_ id: UUID) async throws {
+        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+
+            guard let managed = response.first else {
+                throw RetrospectError.notFound
+            }
+
+            coreDataStack.viewContext.delete(managed)
+            try coreDataStack.saveContext(coreDataStack.viewContext)
+        } catch {
+            throw error
+        }
+    }
+}

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -104,7 +104,7 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
             let response = try coreDataStack.viewContext.fetch(request)
 
             guard let managed = response.first else {
-                throw RetrospectError.notFound
+                throw RetrospectError.itemNotFound
             }
 
             RetrospectItemMapper.update(managed, from: item)
@@ -130,7 +130,7 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
             let response = try coreDataStack.viewContext.fetch(request)
 
             guard let managed = response.first else {
-                throw RetrospectError.notFound
+                throw RetrospectError.itemNotFound
             }
 
             coreDataStack.viewContext.delete(managed)

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectRepository.swift
@@ -1,0 +1,183 @@
+//
+//  CoreDataRetrospectRepository.swift
+//  RetroApp
+//
+//  Created by J on 3/30/26.
+//
+
+import CoreData
+import Foundation
+
+/// ``RetrospectRepositoryProtocol``의 Core Data 구현체.
+///
+/// Domain 레이어의 ``Retrospect`` Entity를 Core Data로 저장/조회/수정/삭제한다.
+/// ``RetrospectMapper``를 통해 ManagedObject와 Domain Entity 간 변환을 수행한다.
+final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
+
+    // MARK: - Properties
+
+    private let coreDataStack: CoreDataStack
+
+    // MARK: - Init
+
+    init(coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
+    }
+
+    // MARK: - CRUD
+
+    /// 새 회고를 Core Data에 저장한다.
+    ///
+    /// UseCase에서 `id`와 `createdAt`이 할당된 상태로 전달된다.
+    /// - Parameter retrospect: 저장할 회고
+    /// - Returns: 저장된 회고
+    func save(_ retrospect: Retrospect) async throws -> Retrospect {
+        _ = RetrospectMapper.toManagedObject(retrospect, context: coreDataStack.viewContext)
+        try coreDataStack.saveContext(coreDataStack.viewContext)
+        return retrospect
+    }
+
+    /// 전체 회고 목록을 최신순으로 조회한다.
+    ///
+    /// `createdAt` 내림차순으로 정렬하여 반환한다.
+    /// - Returns: 회고 배열
+    func fetchAll() async throws -> [Retrospect] {
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        request.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: false)]
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+            return response.map { RetrospectMapper.toEntity($0) }
+        } catch {
+            throw error
+        }
+    }
+
+    /// 특정 회고를 ID로 조회한다.
+    ///
+    /// - Parameter id: 조회할 회고의 식별자
+    /// - Returns: 해당 회고
+    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 회고가 없을 때
+    func fetchById(_ id: UUID) async throws -> Retrospect {
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+
+            guard let managed = response.first else {
+                throw RetrospectError.notFound
+            }
+
+            return RetrospectMapper.toEntity(managed)
+        } catch {
+            throw error
+        }
+    }
+
+    /// 특정 날짜의 회고 목록을 조회한다.
+    ///
+    /// 해당 날짜의 00:00:00부터 다음 날 00:00:00 사이의 회고를 반환한다.
+    /// 달력 뷰에서 날짜를 탭했을 때 사용한다.
+    /// - Parameter date: 조회할 날짜 (시간 무시, 날짜만 비교)
+    /// - Returns: 해당 날짜의 회고 배열
+    func fetchByDate(_ date: Date) async throws -> [Retrospect] {
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+
+        let start = Calendar.current.startOfDay(for: date)
+        let end = Calendar.current.date(byAdding: .day, value: 1, to: start)!
+
+        request.predicate = NSPredicate(
+            format: "createdAt >= %@ AND createdAt < %@",
+            start as CVarArg,
+            end as CVarArg
+        )
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+            return response.map { RetrospectMapper.toEntity($0) }
+        } catch {
+            throw error
+        }
+    }
+
+    /// 기존 회고를 업데이트한다.
+    ///
+    /// ID로 기존 ManagedObject를 찾아 ``RetrospectMapper``로 값을 덮어쓴다.
+    /// - Parameter retrospect: 업데이트할 회고
+    /// - Returns: 업데이트된 회고
+    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 회고가 없을 때
+    func update(_ retrospect: Retrospect) async throws -> Retrospect {
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        request.predicate = NSPredicate(format: "id == %@", retrospect.id as CVarArg)
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+
+            guard let managed = response.first else {
+                throw RetrospectError.notFound
+            }
+
+            RetrospectMapper.update(managed, from: retrospect)
+            try coreDataStack.saveContext(coreDataStack.viewContext)
+
+            return retrospect
+        } catch {
+            throw error
+        }
+    }
+
+    /// 회고를 삭제한다.
+    ///
+    /// ID로 ManagedObject를 찾아 context에서 삭제한다.
+    /// 연관된 ``RetrospectItem``의 cascade 삭제는 Core Data relationship 설정에 의존한다.
+    /// - Parameter id: 삭제할 회고의 식별자
+    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 회고가 없을 때
+    func delete(_ id: UUID) async throws {
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+
+            guard let managed = response.first else {
+                throw RetrospectError.notFound
+            }
+
+            coreDataStack.viewContext.delete(managed)
+            try coreDataStack.saveContext(coreDataStack.viewContext)
+        } catch {
+            throw error
+        }
+    }
+
+    // MARK: - Calendar
+
+    /// 해당 월에 회고가 존재하는 날짜 목록을 조회한다.
+    ///
+    /// 해당 월 1일 00:00:00부터 다음 달 1일 00:00:00 사이의 회고에서
+    /// `createdAt`만 추출하여 반환한다.
+    /// 달력 뷰에서 회고가 있는 날짜에 점을 표시하기 위해 사용한다.
+    /// - Parameter month: 조회할 월 (해당 월의 아무 날짜)
+    /// - Returns: 회고가 있는 날짜 배열
+    func fetchDatesWithRetrospect(in month: Date) async throws -> [Date] {
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+
+        let components = Calendar.current.dateComponents([.year, .month], from: month)
+        let start = Calendar.current.date(from: components)!
+        let end = Calendar.current.date(byAdding: .month, value: 1, to: start)!
+
+        request.predicate = NSPredicate(
+            format: "createdAt >= %@ AND createdAt < %@",
+            start as CVarArg,
+            end as CVarArg
+        )
+
+        do {
+            let response = try coreDataStack.viewContext.fetch(request)
+            return response.compactMap { $0.createdAt }
+        } catch {
+            throw error
+        }
+    }
+}

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectRepository.swift
@@ -66,7 +66,7 @@ final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
             let response = try coreDataStack.viewContext.fetch(request)
 
             guard let managed = response.first else {
-                throw RetrospectError.notFound
+                throw RetrospectError.retrospectNotFound
             }
 
             return RetrospectMapper.toEntity(managed)
@@ -115,7 +115,7 @@ final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
             let response = try coreDataStack.viewContext.fetch(request)
 
             guard let managed = response.first else {
-                throw RetrospectError.notFound
+                throw RetrospectError.retrospectNotFound
             }
 
             RetrospectMapper.update(managed, from: retrospect)
@@ -141,7 +141,7 @@ final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
             let response = try coreDataStack.viewContext.fetch(request)
 
             guard let managed = response.first else {
-                throw RetrospectError.notFound
+                throw RetrospectError.retrospectNotFound
             }
 
             coreDataStack.viewContext.delete(managed)

--- a/RetroApp/RetroApp/Data/RetroApp.xcdatamodeld/RetroApp.xcdatamodel/contents
+++ b/RetroApp/RetroApp/Data/RetroApp.xcdatamodeld/RetroApp.xcdatamodel/contents
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24512" systemVersion="24G222" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="RetrospectEntity" representedClassName="RetrospectEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="confirmedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="formatId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isEdited" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="sessionId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="status" attributeType="String"/>
+        <attribute name="teamId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="timerDuration" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="type" attributeType="String"/>
+    </entity>
+    <entity name="RetrospectFormatEntity" representedClassName="RetrospectFormatEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="categoriesJSON" attributeType="String"/>
+        <attribute name="descriptionText" attributeType="String"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isBuiltIn" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="recommendWhen" attributeType="String"/>
+    </entity>
+    <entity name="RetrospectItemEntity" representedClassName="RetrospectItemEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="categoryName" attributeType="String"/>
+        <attribute name="content" attributeType="String"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isResolved" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="linkedTryId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="retrospectId" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+</model>

--- a/RetroApp/RetroApp/Data/RetroApp.xcdatamodeld/RetroApp.xcdatamodel/contents
+++ b/RetroApp/RetroApp/Data/RetroApp.xcdatamodeld/RetroApp.xcdatamodel/contents
@@ -12,6 +12,7 @@
         <attribute name="timerDuration" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="type" attributeType="String"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="RetrospectItemEntity" inverseName="retrospect" inverseEntity="RetrospectItemEntity"/>
     </entity>
     <entity name="RetrospectFormatEntity" representedClassName="RetrospectFormatEntity" syncable="YES" codeGenerationType="class">
         <attribute name="categoriesJSON" attributeType="String"/>
@@ -29,5 +30,6 @@
         <attribute name="linkedTryId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="retrospectId" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="retrospect" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RetrospectEntity" inverseName="items" inverseEntity="RetrospectEntity"/>
     </entity>
 </model>

--- a/RetroApp/RetroApp/Domain/Enums/RetrospectError.swift
+++ b/RetroApp/RetroApp/Domain/Enums/RetrospectError.swift
@@ -19,7 +19,13 @@ enum RetrospectError: LocalizedError, Sendable {
     case alreadyConfirmed
 
     /// 요청한 회고를 찾을 수 없음
-    case notFound
+    case retrospectNotFound
+
+    /// 요청한 회고 항목을 찾을 수 없음
+    case itemNotFound
+
+    /// 요청한 회고 포맷을 찾을 수 없음
+    case formatNotFound
 
     /// 빌트인 포맷을 삭제 시도
     case cannotDeleteBuiltInFormat
@@ -30,10 +36,15 @@ enum RetrospectError: LocalizedError, Sendable {
             return "항목이 최소 1개 이상 필요합니다"
         case .alreadyConfirmed:
             return "이미 제출된 회고입니다"
-        case .notFound:
+        case .retrospectNotFound:
             return "회고를 찾을 수 없습니다"
+        case .itemNotFound:
+            return "회고 항목을 찾을 수 없습니다"
+        case .formatNotFound:
+            return "회고 포맷을 찾을 수 없습니다"
         case .cannotDeleteBuiltInFormat:
             return "기본 제공 포맷은 삭제할 수 없습니다"
+
         }
     }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈
<!-- closes #이슈번호 (머지 시 이슈 자동 닫힘) -->
closes #7

---

## ✨ What's this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

Domain 레이어의 Entity/Protocol을 실제로 동작하게 하는 Data 레이어를 구현합니다.
Core Data를 활용한 로컬 저장소로, ManagedObject와 Domain Entity를 Mapper로 변환합니다.

Core Data 스키마:
- `RetroApp.xcdatamodeld` — RetrospectEntity, RetrospectItemEntity, RetrospectFormatEntity

CoreDataStack:
- `Data/CoreData/CoreDataStack.swift` — NSPersistentContainer 세팅

Mapper:
- `Data/Mapper/RetrospectMapper.swift`
- `Data/Mapper/RetrospectItemMapper.swift`
- `Data/Mapper/RetrospectFormatMapper.swift`

Repository 구현체:
- `Data/Repository/CoreDataRetrospectRepository.swift`
- `Data/Repository/CoreDataRetrospectItemRepository.swift`
- `Data/Repository/CoreDataRetrospectFormatRepository.swift`

---

### 🏗️ 구현 방식
<!-- 핵심 기술적 결정, 아키텍처 선택 이유, 사용한 패턴 등 -->

### 🏗️ 구현 방식

#### Core Data 스키마 설계

Domain Entity를 Core Data Entity로 매핑했습니다.
Codegen은 Class Definition으로 설정하여 Xcode가 ManagedObject를 자동 생성합니다.

| Domain Entity | Core Data Entity | 특이사항 |
| --- | --- | --- |
| Retrospect | RetrospectEntity | status, type은 String으로 저장 (enum rawValue) |
| RetrospectItem | RetrospectItemEntity | order는 Integer 32 |
| RetrospectFormat | RetrospectFormatEntity | categories는 JSON 문자열로 저장 |

`RetrospectFormat`의 `categories: [CategoryTemplate]`는 Core Data에 배열을 직접 저장할 수 없으므로,
JSON 문자열로 인코딩하여 `categoriesJSON` Attribute에 저장합니다.
`description`은 NSObject 예약어이므로 `descriptionText`로 이름을 변경했습니다.

#### CoreDataStack
```swift
final class CoreDataStack {
    private let container: NSPersistentContainer
    var viewContext: NSManagedObjectContext { container.viewContext }
    func newBackgroundContext() -> NSManagedObjectContext
    func saveContext(_ context: NSManagedObjectContext) throws
}
```

- `automaticallyMergesChangesFromParent = true`: 백그라운드 저장 시 viewContext에 자동 반영
- `mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump`: 충돌 시 후입 우선
- `saveContext`는 변경사항이 없으면 스킵하여 불필요한 I/O 방지

#### Mapper 패턴

ManagedObject ↔ Domain Entity 변환을 `enum`으로 구현했습니다.
인스턴스 생성이 불필요한 유틸리티이므로 case 없는 enum을 사용합니다.

각 Mapper는 3가지 메서드를 제공합니다:

| 메서드 | 용도 |
| --- | --- |
| `toEntity(_:)` | ManagedObject → Domain Entity (조회 시) |
| `toManagedObject(_:context:)` | Domain Entity → 새 ManagedObject (저장 시) |
| `update(_:from:)` | 기존 ManagedObject에 Domain Entity 값 덮어쓰기 (수정 시) |

#### Repository 구현체

모든 Repository는 동일한 패턴을 따릅니다:

조회: NSFetchRequest → predicate/sortDescriptor 설정 → context.fetch → Mapper.toEntity
저장: Mapper.toManagedObject → saveContext
수정: NSFetchRequest로 기존 객체 조회 → Mapper.update → saveContext
삭제: NSFetchRequest로 조회 → context.delete → saveContext

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 성공
- [x] Core Data 스키마와 Mapper 간 타입 매핑 일치 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

NSPredicate의 CVarArg:
Core Data의 NSPredicate가 Objective-C 기반이라,
Swift 타입(UUID 등)을 Objective-C에서 사용할 수 있도록 `as CVarArg`로 변환합니다.

날짜 비교 (fetchByDate):
`createdAt`에 시간이 포함되어 있으므로 날짜 범위로 비교합니다.
`startOfDay` ~ `startOfDay + 1일` 범위를 사용합니다.
```swift
let start = Calendar.current.startOfDay(for: date)
let end = Calendar.current.date(byAdding: .day, value: 1, to: start)!
request.predicate = NSPredicate(format: "createdAt >= %@ AND createdAt < %@", ...)
```

월별 조회 (fetchDatesWithRetrospect):
해당 월 1일 ~ 다음 달 1일 범위로 조회합니다.
`startOfDay`가 아닌 `dateComponents([.year, .month])`를 사용하여
월의 1일부터 조회하도록 합니다.
```swift
let components = Calendar.current.dateComponents([.year, .month], from: month)
let start = Calendar.current.date(from: components)!
```

ManagedObject의 프로퍼티가 대부분 Optional인 이유:
Core Data가 Objective-C 기반이라 ManagedObject는 `init(context:)`로 생성 시
모든 프로퍼티가 nil인 빈 상태로 시작됩니다.
Mapper에서 `?? 기본값`으로 안전하게 변환합니다.

`toManagedObject`에 `context` 파라미터가 필요한 이유:
Core Data의 ManagedObject는 항상 특정 context에 소속되어야 합니다.
`RetrospectEntity(context: context)`로만 생성 가능하며,
이후 `context.save()`를 호출하면 해당 context의 모든 변경사항이 한번에 저장됩니다.