### PR TITLE
♻️ Refactor: #18 코드 리뷰 반영 (Data 레이어)

### DIFF
--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -41,21 +41,22 @@ final class CoreDataStack {
     init(modelName: String = "RetroApp") throws {
         container = NSPersistentContainer(name: modelName)
 
+        let group = DispatchGroup()
         var loadError: Error?
 
-        // SQLite 파일을 열어서 준비하는 과정
+        group.enter()
         container.loadPersistentStores { _, error in
             loadError = error
+            group.leave()
         }
+        group.wait()
 
         if let loadError {
             throw loadError
         }
 
-        // 백그라운드에서 저장하면 viewContext에 자동 반영
         container.viewContext.automaticallyMergesChangesFromParent = true
 
-        // 같은 객체를 중복 생성하지 않고 기존 객체를 재사용
         container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
     }
 

--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -74,9 +74,8 @@ final class CoreDataStack {
     /// 변경사항이 없으면 아무것도 하지 않는다.
     /// - Parameter context: 저장할 Context
     func saveContext(_ context: NSManagedObjectContext) throws {
-        guard context.hasChanges else { return }
-
         try context.performAndWait {
+            guard context.hasChanges else { return }
             try context.save()
         }
     }

--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -75,6 +75,9 @@ final class CoreDataStack {
     /// - Parameter context: 저장할 Context
     func saveContext(_ context: NSManagedObjectContext) throws {
         guard context.hasChanges else { return }
-        try context.save()
+
+        try context.performAndWait {
+            try context.save()
+        }
     }
 }

--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -38,14 +38,18 @@ final class CoreDataStack {
     /// CoreDataStack을 초기화한다.
     ///
     /// - Parameter modelName: .xcdatamodeld 파일 이름. 기본값 "RetroApp"
-    init(modelName: String = "RetroApp") {
+    init(modelName: String = "RetroApp") throws {
         container = NSPersistentContainer(name: modelName)
+
+        var loadError: Error?
 
         // SQLite 파일을 열어서 준비하는 과정
         container.loadPersistentStores { _, error in
-            if let error {
-                fatalError("Core Data 로드 실패: \(error)")
-            }
+            loadError = error
+        }
+
+        if let loadError {
+            throw loadError
         }
 
         // 백그라운드에서 저장하면 viewContext에 자동 반영

--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -38,21 +38,17 @@ final class CoreDataStack {
     /// CoreDataStack을 초기화한다.
     ///
     /// - Parameter modelName: .xcdatamodeld 파일 이름. 기본값 "RetroApp"
-    init(modelName: String = "RetroApp") throws {
+    init(modelName: String = "RetroApp") async throws {
         container = NSPersistentContainer(name: modelName)
 
-        let group = DispatchGroup()
-        var loadError: Error?
-
-        group.enter()
-        container.loadPersistentStores { _, error in
-            loadError = error
-            group.leave()
-        }
-        group.wait()
-
-        if let loadError {
-            throw loadError
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            container.loadPersistentStores { _, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
         }
 
         container.viewContext.automaticallyMergesChangesFromParent = true

--- a/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
+++ b/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
@@ -29,11 +29,13 @@ enum RetrospectItemMapper {
 
     static func toManagedObject(
         _ entity: RetrospectItem,
+        retrospect: RetrospectEntity,
         context: NSManagedObjectContext,
     ) -> RetrospectItemEntity {
         let managed = RetrospectItemEntity(context: context)
 
         managed.id = entity.id
+        managed.retrospect = retrospect
         managed.retrospectId = entity.retrospectId
         managed.categoryName = entity.categoryName
         managed.content = entity.content

--- a/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
+++ b/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
@@ -35,8 +35,8 @@ enum RetrospectItemMapper {
         let managed = RetrospectItemEntity(context: context)
 
         managed.id = entity.id
+        managed.retrospectId = retrospect.id
         managed.retrospect = retrospect
-        managed.retrospectId = entity.retrospectId
         managed.categoryName = entity.categoryName
         managed.content = entity.content
         managed.linkedTryId = entity.linkedTryId

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
@@ -49,7 +49,7 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
     ///
     /// - Parameter id: 조회할 포맷의 식별자
     /// - Returns: 해당 포맷
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 포맷이 없을 때
+    /// - Throws: ``RetrospectError/formatNotFound`` — 해당 ID의 포맷이 없을 때
     func fetchById(_ id: UUID) async throws -> RetrospectFormat {
         let request = NSFetchRequest<RetrospectFormatEntity>(entityName: "RetrospectFormatEntity")
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
@@ -88,7 +88,7 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
     ///
     /// 빌트인 포맷은 삭제할 수 없다. 시도 시 ``RetrospectError/cannotDeleteBuiltInFormat`` 에러.
     /// - Parameter id: 삭제할 포맷의 식별자
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 포맷이 없을 때
+    /// - Throws: ``RetrospectError/formatNotFound`` — 해당 ID의 포맷이 없을 때
     /// - Throws: ``RetrospectError/cannotDeleteBuiltInFormat`` — 빌트인 포맷 삭제 시도 시
     func delete(_ id: UUID) async throws {
         let request = NSFetchRequest<RetrospectFormatEntity>(entityName: "RetrospectFormatEntity")

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
@@ -77,7 +77,7 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
     func save(_ format: RetrospectFormat) async throws -> RetrospectFormat {
         let managed = RetrospectFormatMapper.toManagedObject(format, context: coreDataStack.viewContext)
         managed.isBuiltIn = false
-        
+
         try coreDataStack.saveContext(coreDataStack.viewContext)
         return format
     }

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -31,7 +31,16 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     /// - Parameter item: 저장할 항목
     /// - Returns: 저장된 항목
     func save(_ item: RetrospectItem) async throws -> RetrospectItem {
-        _ = RetrospectItemMapper.toManagedObject(item, context: coreDataStack.viewContext)
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        request.predicate = NSPredicate(format: "id == %@", item.retrospectId as CVarArg)
+
+        let response = try coreDataStack.viewContext.fetch(request)
+
+        guard let retrospect = response.first else {
+            throw RetrospectError.retrospectNotFound
+        }
+
+        _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
         try coreDataStack.saveContext(coreDataStack.viewContext)
         return item
     }
@@ -43,8 +52,19 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     /// - Parameter items: 저장할 항목 배열
     /// - Returns: 저장된 항목 배열
     func saveAll(_ items: [RetrospectItem]) async throws -> [RetrospectItem] {
+        guard let firstItem = items.first else { return items }
+
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        request.predicate = NSPredicate(format: "id == %@", firstItem.retrospectId as CVarArg)
+
+        let response = try coreDataStack.viewContext.fetch(request)
+
+        guard let retrospect = response.first else {
+            throw RetrospectError.retrospectNotFound
+        }
+
         for item in items {
-            _ = RetrospectItemMapper.toManagedObject(item, context: coreDataStack.viewContext)
+            _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
         }
 
         try coreDataStack.saveContext(coreDataStack.viewContext)
@@ -86,6 +106,43 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
         } catch {
             throw error
         }
+    }
+
+    // MARK: - Replace
+
+    /// 특정 회고의 항목을 전부 교체한다.
+    ///
+    /// 기존 항목을 모두 삭제하고 새 항목으로 대체한다.
+    /// 수정 시 중복 생성을 방지한다.
+    /// - Parameters:
+    ///   - retrospectId: 대상 회고의 식별자
+    ///   - items: 새로 저장할 항목 배열
+    /// - Returns: 저장된 항목 배열
+    func replaceAll(retrospectId: UUID, items: [RetrospectItem]) async throws -> [RetrospectItem] {
+        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
+        request.predicate = NSPredicate(format: "retrospectId == %@", retrospectId as CVarArg)
+
+        let response = try coreDataStack.viewContext.fetch(request)
+
+        for managed in response {
+            coreDataStack.viewContext.delete(managed)
+        }
+
+        let retroRequest = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        retroRequest.predicate = NSPredicate(format: "id == %@", retrospectId as CVarArg)
+
+        let retroResponse = try coreDataStack.viewContext.fetch(retroRequest)
+
+        guard let retrospect = retroResponse.first else {
+            throw RetrospectError.retrospectNotFound
+        }
+
+        for item in items {
+            _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
+        }
+
+        try coreDataStack.saveContext(coreDataStack.viewContext)
+        return items
     }
 
     // MARK: - Update

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -119,15 +119,6 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     ///   - items: 새로 저장할 항목 배열
     /// - Returns: 저장된 항목 배열
     func replaceAll(retrospectId: UUID, items: [RetrospectItem]) async throws -> [RetrospectItem] {
-        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
-        request.predicate = NSPredicate(format: "retrospectId == %@", retrospectId as CVarArg)
-
-        let response = try coreDataStack.viewContext.fetch(request)
-
-        for managed in response {
-            coreDataStack.viewContext.delete(managed)
-        }
-
         let retroRequest = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         retroRequest.predicate = NSPredicate(format: "id == %@", retrospectId as CVarArg)
 
@@ -135,6 +126,15 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
 
         guard let retrospect = retroResponse.first else {
             throw RetrospectError.retrospectNotFound
+        }
+
+        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
+        request.predicate = NSPredicate(format: "retrospectId == %@", retrospectId as CVarArg)
+
+        let response = try coreDataStack.viewContext.fetch(request)
+
+        for managed in response {
+            coreDataStack.viewContext.delete(managed)
         }
 
         for item in items {

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -138,6 +138,9 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
         }
 
         for item in items {
+            guard item.retrospectId == retrospectId else {
+                throw RetrospectError.mismatchedRetrospectId
+            }
             _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
         }
 

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -95,7 +95,7 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     /// ID로 기존 ManagedObject를 찾아 ``RetrospectItemMapper``로 값을 덮어쓴다.
     /// - Parameter item: 업데이트할 항목
     /// - Returns: 업데이트된 항목
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 항목이 없을 때
+    /// - Throws: ``RetrospectError/itemNotFound`` — 해당 ID의 항목이 없을 때
     func update(_ item: RetrospectItem) async throws -> RetrospectItem {
         let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
         request.predicate = NSPredicate(format: "id == %@", item.id as CVarArg)
@@ -121,7 +121,7 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     /// 회고 항목을 삭제한다.
     ///
     /// - Parameter id: 삭제할 항목의 식별자
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 항목이 없을 때
+    /// - Throws: ``RetrospectError/itemNotFound`` — 해당 ID의 항목이 없을 때
     func delete(_ id: UUID) async throws {
         let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectRepository.swift
@@ -57,7 +57,7 @@ final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
     ///
     /// - Parameter id: 조회할 회고의 식별자
     /// - Returns: 해당 회고
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 회고가 없을 때
+    /// - Throws: ``RetrospectError/retrospectNotFound`` — 해당 ID의 회고가 없을 때
     func fetchById(_ id: UUID) async throws -> Retrospect {
         let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
@@ -106,7 +106,7 @@ final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
     /// ID로 기존 ManagedObject를 찾아 ``RetrospectMapper``로 값을 덮어쓴다.
     /// - Parameter retrospect: 업데이트할 회고
     /// - Returns: 업데이트된 회고
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 회고가 없을 때
+    /// - Throws: ``RetrospectError/retrospectNotFound`` — 해당 ID의 회고가 없을 때
     func update(_ retrospect: Retrospect) async throws -> Retrospect {
         let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         request.predicate = NSPredicate(format: "id == %@", retrospect.id as CVarArg)
@@ -132,7 +132,7 @@ final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
     /// ID로 ManagedObject를 찾아 context에서 삭제한다.
     /// 연관된 ``RetrospectItem``의 cascade 삭제는 Core Data relationship 설정에 의존한다.
     /// - Parameter id: 삭제할 회고의 식별자
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 회고가 없을 때
+    /// - Throws: ``RetrospectError/retrospectNotFound`` — 해당 ID의 회고가 없을 때
     func delete(_ id: UUID) async throws {
         let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)

--- a/RetroApp/RetroApp/Domain/Enums/RetrospectError.swift
+++ b/RetroApp/RetroApp/Domain/Enums/RetrospectError.swift
@@ -30,6 +30,9 @@ enum RetrospectError: LocalizedError, Sendable {
     /// 빌트인 포맷을 삭제 시도
     case cannotDeleteBuiltInFormat
 
+    /// 항목의 retrospectId가 불일치할 때
+    case mismatchedRetrospectId
+
     var errorDescription: String? {
         switch self {
         case .emptyItems:
@@ -42,6 +45,8 @@ enum RetrospectError: LocalizedError, Sendable {
             return "회고 항목을 찾을 수 없습니다"
         case .formatNotFound:
             return "회고 포맷을 찾을 수 없습니다"
+        case .mismatchedRetrospectId:
+            return "항목의 회고 ID가 일치하지 않습니다"
         case .cannotDeleteBuiltInFormat:
             return "기본 제공 포맷은 삭제할 수 없습니다"
 

--- a/RetroApp/RetroApp/Domain/Repositories/RetrospectItemRepositoryProtocol.swift
+++ b/RetroApp/RetroApp/Domain/Repositories/RetrospectItemRepositoryProtocol.swift
@@ -32,6 +32,12 @@ protocol RetrospectItemRepositoryProtocol: Sendable {
     /// - Returns: 항목 배열
     func fetchByRetrospectId(_ retrospectId: UUID) async throws -> [RetrospectItem]
 
+    /// 특정 회고의 항목을 전부 교체한다.
+    ///
+    /// 기존 항목을 모두 삭제하고 새 항목으로 대체한다.
+    /// 수정 시 중복 생성을 방지한다.
+    func replaceAll(retrospectId: UUID, items: [RetrospectItem]) async throws -> [RetrospectItem]
+
     /// 회고 항목을 업데이트한다.
     ///
     /// 내용 수정, 순서 변경, 해결 여부 변경 시 사용한다.

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -74,7 +74,7 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
 
         let savedRetrospect = try await retrospectRepository.update(updated)
 
-        _ = try await itemRepository.saveAll(items)
+        _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: items)
 
         return savedRetrospect
 

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -74,7 +74,18 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
 
         let savedRetrospect = try await retrospectRepository.update(updated)
 
-        _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: items)
+        let normalizedItems = items.map { item in
+            RetrospectItem(
+                id: item.id,
+                retrospectId: retrospect.id,
+                categoryName: item.categoryName,
+                content: item.content,
+                linkedTryId: item.linkedTryId,
+                isResolved: item.isResolved,
+                order: item.order
+            )
+        }
+        _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: normalizedItems)
 
         return savedRetrospect
 

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -77,7 +77,7 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
         let normalizedItems = items.map { item in
             RetrospectItem(
                 id: item.id,
-                retrospectId: retrospect.id,
+                retrospectId: savedRetrospect.id,
                 categoryName: item.categoryName,
                 content: item.content,
                 linkedTryId: item.linkedTryId,
@@ -88,6 +88,5 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
         _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: normalizedItems)
 
         return savedRetrospect
-
     }
 }

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -85,7 +85,7 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
                 order: item.order
             )
         }
-        _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: normalizedItems)
+        _ = try await itemRepository.replaceAll(retrospectId: savedRetrospect.id, items: normalizedItems)
 
         return savedRetrospect
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈
<!-- closes #이슈번호 (머지 시 이슈 자동 닫힘) -->
closes #18

---

## ✨ What's this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->


머지 후 Copilot 코드 리뷰에서 지적된 6가지 사항을 반영합니다.

---

### 🏗️ 구현 방식
<!-- 핵심 기술적 결정, 아키텍처 선택 이유, 사용한 패턴 등 -->

#### 1. DocC 심볼 링크 수정

`RetrospectError/notFound`가 `retrospectNotFound`/`itemNotFound`/`formatNotFound`로
분리되었으나 DocC 주석이 업데이트되지 않은 부분을 전체 수정했습니다.

#### 2. Core Data Relationship 동기화

기존에는 `RetrospectItemMapper`에서 `retrospectId` Attribute만 설정하고
Core Data relationship은 설정하지 않아 cascade 삭제가 동작하지 않았습니다.
```swift
// Before — relationship 미설정
static func toManagedObject(_ entity: RetrospectItem, context: NSManagedObjectContext)

// After — RetrospectEntity를 받아 relationship 설정
static func toManagedObject(_ entity: RetrospectItem, retrospect: RetrospectEntity, context: NSManagedObjectContext)
```

Repository에서 RetrospectEntity를 조회하여 Mapper에 전달하도록 변경했습니다.

#### 3. replaceAll 도입 (중복 생성 방지)

`UpdateRetrospectUseCase`에서 `saveAll`을 호출하면 기존 항목이 남은 채 새 항목이 추가되어
중복이 발생하는 문제를 해결했습니다.
```swift
// Before — 항상 insert, 중복 발생
_ = try await itemRepository.saveAll(items)

// After — 기존 삭제 후 insert
_ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: items)
```

`replaceAll` 흐름:
1. retrospectId로 기존 항목 전체 조회
2. 기존 항목 전부 delete
3. RetrospectEntity 조회 (relationship 설정용)
4. 새 항목 insert (relationship 포함)
5. saveContext 한 번만 호출

Protocol, Repository 구현체, UseCase 모두 반영했습니다.

#### 4. CoreDataStack fatalError 제거

Core Data 로드 실패 시 앱이 크래시되는 대신 에러를 전파하도록 변경했습니다.
```swift
// Before — 크래시
container.loadPersistentStores { _, error in
    if let error { fatalError("Core Data 로드 실패: \(error)") }
}

// After — 에러 전파
var loadError: Error?
container.loadPersistentStores { _, error in
    loadError = error
}
if let loadError { throw loadError }
```

`init`에 `throws`를 추가하여 호출 측에서 에러 처리가 가능합니다.

#### 5. saveContext에 performAndWait 래핑

Core Data context는 자기 전용 큐에서만 접근해야 안전합니다.
`performAndWait`으로 감싸서 thread safety를 보장합니다.
```swift
// Before — 큐 보장 없음
func saveContext(_ context: NSManagedObjectContext) throws {
    guard context.hasChanges else { return }
    try context.save()
}

// After — 큐 보장
func saveContext(_ context: NSManagedObjectContext) throws {
    guard context.hasChanges else { return }
    try context.performAndWait {
        try context.save()
    }
}
```

#### 6. backgroundContext 사용 (보류)

현재 viewContext 기반으로 유지합니다.
데이터 규모가 커질 경우 backgroundContext 전환은
성능 최적화 단계에서 진행할 예정입니다.

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 성공
- [x] Swift 6 Strict Concurrency 경고 대응 (performAndWait throws 활용)
- [x] DocC 심볼 링크 전체 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- Copilot 리뷰를 통해 발견된 cascade 삭제 미동작, 중복 생성, 크래시 가능성을 해결했습니다.
- backgroundContext 전환은 성능 최적화 이슈로 별도 관리합니다.
