### PR TITLE
✨ Feature: #9 Presentation 레이어 구현

### DIFF
--- a/RetroApp/RetroApp.xcodeproj/project.pbxproj
+++ b/RetroApp/RetroApp.xcodeproj/project.pbxproj
@@ -161,7 +161,6 @@
 				INFOPLIST_FILE = RetroApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -197,7 +196,6 @@
 				INFOPLIST_FILE = RetroApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/RetroApp/RetroApp/Application/DIContainer/DIContainer.swift
+++ b/RetroApp/RetroApp/Application/DIContainer/DIContainer.swift
@@ -1,0 +1,62 @@
+//
+//  DIContainer.swift
+//  RetroApp
+//
+//  Created by J on 3/30/26.
+//
+
+import Foundation
+
+/// 앱 전체의 의존성을 조립하는 컨테이너.
+///
+/// CoreDataStack → Repository → UseCase 순서로 생성하며,
+/// `lazy var`로 필요한 시점에 초기화된다.
+final class DIContainer {
+
+    // MARK: - Core Data
+
+    lazy var coreDataStack = CoreDataStack()
+
+    // MARK: - Repository
+
+    lazy var retrospectRepository = CoreDataRetrospectRepository(coreDataStack: coreDataStack)
+    lazy var retrospectItemRepository = CoreDataRetrospectItemRepository(coreDataStack: coreDataStack)
+    lazy var retrospectFormatRepository = CoreDataRetrospectFormatRepository(coreDataStack: coreDataStack)
+
+    // MARK: - UseCase
+
+    lazy var createRetrospectUseCase = CreateRetrospectUseCase(
+        retrospectRepository: retrospectRepository,
+        itemRepository: retrospectItemRepository
+    )
+
+    lazy var fetchRetrospectListUseCase = FetchRetrospectListUseCase(
+        repository: retrospectRepository
+    )
+
+    lazy var fetchRetrospectByDateUseCase = FetchRetrospectByDateUseCase(
+        repository: retrospectRepository
+    )
+
+    lazy var updateRetrospectUseCase = UpdateRetrospectUseCase(
+        retrospectRepository: retrospectRepository,
+        itemRepository: retrospectItemRepository
+    )
+
+    lazy var deleteRetrospectUseCase = DeleteRetrospectUseCase(
+        repository: retrospectRepository
+    )
+
+    lazy var confirmRetrospectUseCase = ConfirmRetrospectUseCase(
+        retrospectRepository: retrospectRepository,
+        itemRepository: retrospectItemRepository
+    )
+
+    lazy var fetchUnresolvedTriesUseCase = FetchUnresolvedTriesUseCase(
+        repository: retrospectItemRepository
+    )
+
+    lazy var fetchRetrospectFormatsUseCase = FetchRetrospectFormatsUseCase(
+        repository: retrospectFormatRepository
+    )
+}

--- a/RetroApp/RetroApp/Application/DIContainer/DIContainer.swift
+++ b/RetroApp/RetroApp/Application/DIContainer/DIContainer.swift
@@ -15,13 +15,19 @@ final class DIContainer {
 
     // MARK: - Core Data
 
-    lazy var coreDataStack = CoreDataStack()
+    let coreDataStack: CoreDataStack
 
     // MARK: - Repository
 
     lazy var retrospectRepository = CoreDataRetrospectRepository(coreDataStack: coreDataStack)
     lazy var retrospectItemRepository = CoreDataRetrospectItemRepository(coreDataStack: coreDataStack)
     lazy var retrospectFormatRepository = CoreDataRetrospectFormatRepository(coreDataStack: coreDataStack)
+
+    // MARK: - Init
+
+    init(coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
+    }
 
     // MARK: - UseCase
 

--- a/RetroApp/RetroApp/Application/SceneDelegate.swift
+++ b/RetroApp/RetroApp/Application/SceneDelegate.swift
@@ -3,7 +3,11 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         let window = UIWindow(windowScene: windowScene)

--- a/RetroApp/RetroApp/Application/SceneDelegate.swift
+++ b/RetroApp/RetroApp/Application/SceneDelegate.swift
@@ -13,15 +13,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         let window = UIWindow(windowScene: windowScene)
         self.window = window
-        let navigationController = UINavigationController()
-        let diContainer = DIContainer()
-        let coordinator = AppCoordinator(
-            navigationController: navigationController,
-            diContainer: diContainer,
-            window: window
-        )
-        self.coordinator = coordinator
-        coordinator.start()
+
+        Task {
+            let coreDataStack = try await CoreDataStack()
+            let diContainer = DIContainer(coreDataStack: coreDataStack)
+            let navigationController = UINavigationController()
+            let coordinator = AppCoordinator(
+                navigationController: navigationController,
+                diContainer: diContainer,
+                window: window
+            )
+            self.coordinator = coordinator
+            coordinator.start()
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/RetroApp/RetroApp/Application/SceneDelegate.swift
+++ b/RetroApp/RetroApp/Application/SceneDelegate.swift
@@ -3,21 +3,19 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
-    func scene(
-        _ scene: UIScene,
-        willConnectTo session: UISceneSession,
-        options connectionOptions: UIScene.ConnectionOptions
-    ) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene
-        // `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see
-        // `application:configurationForConnectingSceneSession` instead).
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
-        window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UIViewController()
-        window?.makeKeyAndVisible()
+        let window = UIWindow(windowScene: windowScene)
+        self.window = window
+        let navigationController = UINavigationController()
+        let diContainer = DIContainer()
+        let coordinator = AppCoordinator(
+            navigationController: navigationController,
+            diContainer: diContainer,
+            window: window
+        )
+        coordinator.start()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/RetroApp/RetroApp/Application/SceneDelegate.swift
+++ b/RetroApp/RetroApp/Application/SceneDelegate.swift
@@ -2,6 +2,7 @@ import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
+    private var coordinator: AppCoordinator?
 
     func scene(
         _ scene: UIScene,
@@ -19,6 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             diContainer: diContainer,
             window: window
         )
+        self.coordinator = coordinator
         coordinator.start()
     }
 

--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -41,21 +41,22 @@ final class CoreDataStack {
     init(modelName: String = "RetroApp") throws {
         container = NSPersistentContainer(name: modelName)
 
+        let group = DispatchGroup()
         var loadError: Error?
 
-        // SQLite 파일을 열어서 준비하는 과정
+        group.enter()
         container.loadPersistentStores { _, error in
             loadError = error
+            group.leave()
         }
+        group.wait()
 
         if let loadError {
             throw loadError
         }
 
-        // 백그라운드에서 저장하면 viewContext에 자동 반영
         container.viewContext.automaticallyMergesChangesFromParent = true
 
-        // 같은 객체를 중복 생성하지 않고 기존 객체를 재사용
         container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
     }
 

--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -74,9 +74,8 @@ final class CoreDataStack {
     /// 변경사항이 없으면 아무것도 하지 않는다.
     /// - Parameter context: 저장할 Context
     func saveContext(_ context: NSManagedObjectContext) throws {
-        guard context.hasChanges else { return }
-
         try context.performAndWait {
+            guard context.hasChanges else { return }
             try context.save()
         }
     }

--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -75,6 +75,9 @@ final class CoreDataStack {
     /// - Parameter context: 저장할 Context
     func saveContext(_ context: NSManagedObjectContext) throws {
         guard context.hasChanges else { return }
-        try context.save()
+
+        try context.performAndWait {
+            try context.save()
+        }
     }
 }

--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -38,14 +38,18 @@ final class CoreDataStack {
     /// CoreDataStack을 초기화한다.
     ///
     /// - Parameter modelName: .xcdatamodeld 파일 이름. 기본값 "RetroApp"
-    init(modelName: String = "RetroApp") {
+    init(modelName: String = "RetroApp") throws {
         container = NSPersistentContainer(name: modelName)
+
+        var loadError: Error?
 
         // SQLite 파일을 열어서 준비하는 과정
         container.loadPersistentStores { _, error in
-            if let error {
-                fatalError("Core Data 로드 실패: \(error)")
-            }
+            loadError = error
+        }
+
+        if let loadError {
+            throw loadError
         }
 
         // 백그라운드에서 저장하면 viewContext에 자동 반영

--- a/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
+++ b/RetroApp/RetroApp/Data/CoreData/CoreDataStack.swift
@@ -38,21 +38,17 @@ final class CoreDataStack {
     /// CoreDataStack을 초기화한다.
     ///
     /// - Parameter modelName: .xcdatamodeld 파일 이름. 기본값 "RetroApp"
-    init(modelName: String = "RetroApp") throws {
+    init(modelName: String = "RetroApp") async throws {
         container = NSPersistentContainer(name: modelName)
 
-        let group = DispatchGroup()
-        var loadError: Error?
-
-        group.enter()
-        container.loadPersistentStores { _, error in
-            loadError = error
-            group.leave()
-        }
-        group.wait()
-
-        if let loadError {
-            throw loadError
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            container.loadPersistentStores { _, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
         }
 
         container.viewContext.automaticallyMergesChangesFromParent = true

--- a/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
+++ b/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
@@ -29,11 +29,13 @@ enum RetrospectItemMapper {
 
     static func toManagedObject(
         _ entity: RetrospectItem,
+        retrospect: RetrospectEntity,
         context: NSManagedObjectContext,
     ) -> RetrospectItemEntity {
         let managed = RetrospectItemEntity(context: context)
 
         managed.id = entity.id
+        managed.retrospect = retrospect
         managed.retrospectId = entity.retrospectId
         managed.categoryName = entity.categoryName
         managed.content = entity.content

--- a/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
+++ b/RetroApp/RetroApp/Data/Mapper/RetrospectItemMapper.swift
@@ -35,8 +35,8 @@ enum RetrospectItemMapper {
         let managed = RetrospectItemEntity(context: context)
 
         managed.id = entity.id
+        managed.retrospectId = retrospect.id
         managed.retrospect = retrospect
-        managed.retrospectId = entity.retrospectId
         managed.categoryName = entity.categoryName
         managed.content = entity.content
         managed.linkedTryId = entity.linkedTryId

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
@@ -49,7 +49,7 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
     ///
     /// - Parameter id: 조회할 포맷의 식별자
     /// - Returns: 해당 포맷
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 포맷이 없을 때
+    /// - Throws: ``RetrospectError/formatNotFound`` — 해당 ID의 포맷이 없을 때
     func fetchById(_ id: UUID) async throws -> RetrospectFormat {
         let request = NSFetchRequest<RetrospectFormatEntity>(entityName: "RetrospectFormatEntity")
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
@@ -88,7 +88,7 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
     ///
     /// 빌트인 포맷은 삭제할 수 없다. 시도 시 ``RetrospectError/cannotDeleteBuiltInFormat`` 에러.
     /// - Parameter id: 삭제할 포맷의 식별자
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 포맷이 없을 때
+    /// - Throws: ``RetrospectError/formatNotFound`` — 해당 ID의 포맷이 없을 때
     /// - Throws: ``RetrospectError/cannotDeleteBuiltInFormat`` — 빌트인 포맷 삭제 시도 시
     func delete(_ id: UUID) async throws {
         let request = NSFetchRequest<RetrospectFormatEntity>(entityName: "RetrospectFormatEntity")

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectFormatRepository.swift
@@ -77,7 +77,7 @@ final class CoreDataRetrospectFormatRepository: RetrospectFormatRepositoryProtoc
     func save(_ format: RetrospectFormat) async throws -> RetrospectFormat {
         let managed = RetrospectFormatMapper.toManagedObject(format, context: coreDataStack.viewContext)
         managed.isBuiltIn = false
-        
+
         try coreDataStack.saveContext(coreDataStack.viewContext)
         return format
     }

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -31,7 +31,16 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     /// - Parameter item: 저장할 항목
     /// - Returns: 저장된 항목
     func save(_ item: RetrospectItem) async throws -> RetrospectItem {
-        _ = RetrospectItemMapper.toManagedObject(item, context: coreDataStack.viewContext)
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        request.predicate = NSPredicate(format: "id == %@", item.retrospectId as CVarArg)
+
+        let response = try coreDataStack.viewContext.fetch(request)
+
+        guard let retrospect = response.first else {
+            throw RetrospectError.retrospectNotFound
+        }
+
+        _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
         try coreDataStack.saveContext(coreDataStack.viewContext)
         return item
     }
@@ -43,8 +52,19 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     /// - Parameter items: 저장할 항목 배열
     /// - Returns: 저장된 항목 배열
     func saveAll(_ items: [RetrospectItem]) async throws -> [RetrospectItem] {
+        guard let firstItem = items.first else { return items }
+
+        let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        request.predicate = NSPredicate(format: "id == %@", firstItem.retrospectId as CVarArg)
+
+        let response = try coreDataStack.viewContext.fetch(request)
+
+        guard let retrospect = response.first else {
+            throw RetrospectError.retrospectNotFound
+        }
+
         for item in items {
-            _ = RetrospectItemMapper.toManagedObject(item, context: coreDataStack.viewContext)
+            _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
         }
 
         try coreDataStack.saveContext(coreDataStack.viewContext)
@@ -86,6 +106,43 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
         } catch {
             throw error
         }
+    }
+
+    // MARK: - Replace
+
+    /// 특정 회고의 항목을 전부 교체한다.
+    ///
+    /// 기존 항목을 모두 삭제하고 새 항목으로 대체한다.
+    /// 수정 시 중복 생성을 방지한다.
+    /// - Parameters:
+    ///   - retrospectId: 대상 회고의 식별자
+    ///   - items: 새로 저장할 항목 배열
+    /// - Returns: 저장된 항목 배열
+    func replaceAll(retrospectId: UUID, items: [RetrospectItem]) async throws -> [RetrospectItem] {
+        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
+        request.predicate = NSPredicate(format: "retrospectId == %@", retrospectId as CVarArg)
+
+        let response = try coreDataStack.viewContext.fetch(request)
+
+        for managed in response {
+            coreDataStack.viewContext.delete(managed)
+        }
+
+        let retroRequest = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
+        retroRequest.predicate = NSPredicate(format: "id == %@", retrospectId as CVarArg)
+
+        let retroResponse = try coreDataStack.viewContext.fetch(retroRequest)
+
+        guard let retrospect = retroResponse.first else {
+            throw RetrospectError.retrospectNotFound
+        }
+
+        for item in items {
+            _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
+        }
+
+        try coreDataStack.saveContext(coreDataStack.viewContext)
+        return items
     }
 
     // MARK: - Update

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -119,15 +119,6 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     ///   - items: 새로 저장할 항목 배열
     /// - Returns: 저장된 항목 배열
     func replaceAll(retrospectId: UUID, items: [RetrospectItem]) async throws -> [RetrospectItem] {
-        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
-        request.predicate = NSPredicate(format: "retrospectId == %@", retrospectId as CVarArg)
-
-        let response = try coreDataStack.viewContext.fetch(request)
-
-        for managed in response {
-            coreDataStack.viewContext.delete(managed)
-        }
-
         let retroRequest = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         retroRequest.predicate = NSPredicate(format: "id == %@", retrospectId as CVarArg)
 
@@ -135,6 +126,15 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
 
         guard let retrospect = retroResponse.first else {
             throw RetrospectError.retrospectNotFound
+        }
+
+        let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
+        request.predicate = NSPredicate(format: "retrospectId == %@", retrospectId as CVarArg)
+
+        let response = try coreDataStack.viewContext.fetch(request)
+
+        for managed in response {
+            coreDataStack.viewContext.delete(managed)
         }
 
         for item in items {

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -138,6 +138,9 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
         }
 
         for item in items {
+            guard item.retrospectId == retrospectId else {
+                throw RetrospectError.mismatchedRetrospectId
+            }
             _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
         }
 

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -95,7 +95,7 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     /// ID로 기존 ManagedObject를 찾아 ``RetrospectItemMapper``로 값을 덮어쓴다.
     /// - Parameter item: 업데이트할 항목
     /// - Returns: 업데이트된 항목
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 항목이 없을 때
+    /// - Throws: ``RetrospectError/itemNotFound`` — 해당 ID의 항목이 없을 때
     func update(_ item: RetrospectItem) async throws -> RetrospectItem {
         let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
         request.predicate = NSPredicate(format: "id == %@", item.id as CVarArg)
@@ -121,7 +121,7 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     /// 회고 항목을 삭제한다.
     ///
     /// - Parameter id: 삭제할 항목의 식별자
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 항목이 없을 때
+    /// - Throws: ``RetrospectError/itemNotFound`` — 해당 ID의 항목이 없을 때
     func delete(_ id: UUID) async throws {
         let request = NSFetchRequest<RetrospectItemEntity>(entityName: "RetrospectItemEntity")
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectRepository.swift
@@ -57,7 +57,7 @@ final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
     ///
     /// - Parameter id: 조회할 회고의 식별자
     /// - Returns: 해당 회고
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 회고가 없을 때
+    /// - Throws: ``RetrospectError/retrospectNotFound`` — 해당 ID의 회고가 없을 때
     func fetchById(_ id: UUID) async throws -> Retrospect {
         let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
@@ -106,7 +106,7 @@ final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
     /// ID로 기존 ManagedObject를 찾아 ``RetrospectMapper``로 값을 덮어쓴다.
     /// - Parameter retrospect: 업데이트할 회고
     /// - Returns: 업데이트된 회고
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 회고가 없을 때
+    /// - Throws: ``RetrospectError/retrospectNotFound`` — 해당 ID의 회고가 없을 때
     func update(_ retrospect: Retrospect) async throws -> Retrospect {
         let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         request.predicate = NSPredicate(format: "id == %@", retrospect.id as CVarArg)
@@ -132,7 +132,7 @@ final class CoreDataRetrospectRepository: RetrospectRepositoryProtocol {
     /// ID로 ManagedObject를 찾아 context에서 삭제한다.
     /// 연관된 ``RetrospectItem``의 cascade 삭제는 Core Data relationship 설정에 의존한다.
     /// - Parameter id: 삭제할 회고의 식별자
-    /// - Throws: ``RetrospectError/notFound`` — 해당 ID의 회고가 없을 때
+    /// - Throws: ``RetrospectError/retrospectNotFound`` — 해당 ID의 회고가 없을 때
     func delete(_ id: UUID) async throws {
         let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)

--- a/RetroApp/RetroApp/Domain/Enums/RetrospectError.swift
+++ b/RetroApp/RetroApp/Domain/Enums/RetrospectError.swift
@@ -30,6 +30,9 @@ enum RetrospectError: LocalizedError, Sendable {
     /// 빌트인 포맷을 삭제 시도
     case cannotDeleteBuiltInFormat
 
+    /// 항목의 retrospectId가 불일치할 때
+    case mismatchedRetrospectId
+
     var errorDescription: String? {
         switch self {
         case .emptyItems:
@@ -42,6 +45,8 @@ enum RetrospectError: LocalizedError, Sendable {
             return "회고 항목을 찾을 수 없습니다"
         case .formatNotFound:
             return "회고 포맷을 찾을 수 없습니다"
+        case .mismatchedRetrospectId:
+            return "항목의 회고 ID가 일치하지 않습니다"
         case .cannotDeleteBuiltInFormat:
             return "기본 제공 포맷은 삭제할 수 없습니다"
 

--- a/RetroApp/RetroApp/Domain/Repositories/RetrospectItemRepositoryProtocol.swift
+++ b/RetroApp/RetroApp/Domain/Repositories/RetrospectItemRepositoryProtocol.swift
@@ -32,6 +32,12 @@ protocol RetrospectItemRepositoryProtocol: Sendable {
     /// - Returns: 항목 배열
     func fetchByRetrospectId(_ retrospectId: UUID) async throws -> [RetrospectItem]
 
+    /// 특정 회고의 항목을 전부 교체한다.
+    ///
+    /// 기존 항목을 모두 삭제하고 새 항목으로 대체한다.
+    /// 수정 시 중복 생성을 방지한다.
+    func replaceAll(retrospectId: UUID, items: [RetrospectItem]) async throws -> [RetrospectItem]
+
     /// 회고 항목을 업데이트한다.
     ///
     /// 내용 수정, 순서 변경, 해결 여부 변경 시 사용한다.

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -74,7 +74,7 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
 
         let savedRetrospect = try await retrospectRepository.update(updated)
 
-        _ = try await itemRepository.saveAll(items)
+        _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: items)
 
         return savedRetrospect
 

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -74,7 +74,18 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
 
         let savedRetrospect = try await retrospectRepository.update(updated)
 
-        _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: items)
+        let normalizedItems = items.map { item in
+            RetrospectItem(
+                id: item.id,
+                retrospectId: retrospect.id,
+                categoryName: item.categoryName,
+                content: item.content,
+                linkedTryId: item.linkedTryId,
+                isResolved: item.isResolved,
+                order: item.order
+            )
+        }
+        _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: normalizedItems)
 
         return savedRetrospect
 

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -77,7 +77,7 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
         let normalizedItems = items.map { item in
             RetrospectItem(
                 id: item.id,
-                retrospectId: retrospect.id,
+                retrospectId: savedRetrospect.id,
                 categoryName: item.categoryName,
                 content: item.content,
                 linkedTryId: item.linkedTryId,
@@ -88,6 +88,5 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
         _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: normalizedItems)
 
         return savedRetrospect
-
     }
 }

--- a/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
+++ b/RetroApp/RetroApp/Domain/Usecases/UpdateRetrospectUseCase.swift
@@ -85,7 +85,7 @@ final class UpdateRetrospectUseCase: UpdateRetrospectUseCaseProtocol {
                 order: item.order
             )
         }
-        _ = try await itemRepository.replaceAll(retrospectId: retrospect.id, items: normalizedItems)
+        _ = try await itemRepository.replaceAll(retrospectId: savedRetrospect.id, items: normalizedItems)
 
         return savedRetrospect
     }

--- a/RetroApp/RetroApp/Presentation/Common/Coordinator/AppCoordinator.swift
+++ b/RetroApp/RetroApp/Presentation/Common/Coordinator/AppCoordinator.swift
@@ -1,0 +1,31 @@
+//
+//  AppCoordinator.swift
+//  RetroApp
+//
+//  Created by J on 3/30/26.
+//
+
+import Foundation
+import UIKit
+
+final class AppCoordinator: Coordinator {
+    var navigationController: UINavigationController
+    private let diContainer: DIContainer
+    private let window: UIWindow
+
+    init(navigationController: UINavigationController, diContainer: DIContainer, window: UIWindow) {
+        self.navigationController = navigationController
+        self.diContainer = diContainer
+        self.window = window
+    }
+
+    func start() {
+        let viewModel = RetrospectListViewModel(fetchRetrospectListUseCase: diContainer.fetchRetrospectListUseCase)
+
+        let viewController = RetrospectListViewController(viewModel: viewModel)
+        navigationController.viewControllers = [viewController]
+
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+    }
+}

--- a/RetroApp/RetroApp/Presentation/Common/Coordinator/Coordinator.swift
+++ b/RetroApp/RetroApp/Presentation/Common/Coordinator/Coordinator.swift
@@ -1,0 +1,15 @@
+//
+//  Coordinator.swift
+//  RetroApp
+//
+//  Created by J on 3/30/26.
+//
+
+import Foundation
+import UIKit
+
+protocol Coordinator {
+    var navigationController: UINavigationController { get }
+
+    func start()
+}

--- a/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewController.swift
+++ b/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewController.swift
@@ -72,6 +72,23 @@ final class RetrospectListViewController: UIViewController {
                 self?.tableView.reloadData()
             }
         }
+
+        viewModel.onError = { message in
+            // TODO: Alert으로 교체 예정
+        }
+    }
+
+    // MARK: - Formatter
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 M월 d일 회고"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter
+    }()
+
+    private func formatDate(_ date: Date) -> String {
+        Self.dateFormatter.string(from: date)
     }
 }
 
@@ -86,7 +103,7 @@ extension RetrospectListViewController: UITableViewDataSource {
         let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "RetrospectCell")
         let retrospect = viewModel.retrospects[indexPath.row]
 
-        cell.textLabel?.text = retrospect.title ?? "제목 없음"
+        cell.textLabel?.text = retrospect.title ?? formatDate(retrospect.createdAt)
         cell.detailTextLabel?.text = retrospect.status.rawValue
 
         return cell

--- a/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewController.swift
+++ b/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewController.swift
@@ -8,21 +8,87 @@
 import Foundation
 import UIKit
 
+/// 회고 목록을 표시하는 ViewController.
+///
+/// ``RetrospectListViewModel``에서 데이터를 가져와 UITableView에 표시한다.
+/// ViewModel의 closure 바인딩으로 데이터 변경 시 테이블뷰를 갱신한다.
 final class RetrospectListViewController: UIViewController {
+
+    // MARK: - Properties
+
     private let viewModel: RetrospectListViewModel
+
+    private let tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        return tableView
+    }()
+
+    // MARK: Init
 
     init(viewModel: RetrospectListViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 
-    required init?(coder: NSCoder) {
+    required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
+        title = "내 회고"
+
+        setupTableView()
+        bindViewModel()
         viewModel.fetchRetrospects()
+    }
+
+    // MARK: - Setup
+
+    private func setupTableView() {
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "RetrospectCell")
+    }
+
+    // MARK: - Binding
+
+    /// ViewModel의 데이터 변경을 감지하여 UI를 갱신한다.
+    private func bindViewModel() {
+        viewModel.onRetrospectsFetched = { [weak self] in
+            DispatchQueue.main.async {
+                self?.tableView.reloadData()
+            }
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension RetrospectListViewController: UITableViewDataSource {
+    func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+        viewModel.retrospects.count
+    }
+
+    func tableView(_: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "RetrospectCell")
+        let retrospect = viewModel.retrospects[indexPath.row]
+
+        cell.textLabel?.text = retrospect.title ?? "제목 없음"
+        cell.detailTextLabel?.text = retrospect.status.rawValue
+
+        return cell
     }
 }

--- a/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewController.swift
+++ b/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewController.swift
@@ -1,0 +1,28 @@
+//
+//  RetrospectListViewController.swift
+//  RetroApp
+//
+//  Created by J on 3/30/26.
+//
+
+import Foundation
+import UIKit
+
+final class RetrospectListViewController: UIViewController {
+    private let viewModel: RetrospectListViewModel
+
+    init(viewModel: RetrospectListViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        viewModel.fetchRetrospects()
+    }
+}

--- a/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewModel.swift
+++ b/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  RetrospectListViewModel.swift
+//  RetroApp
+//
+//  Created by J on 3/30/26.
+//
+
+import Foundation
+
+final class RetrospectListViewModel {
+
+    private let fetchRetrospectListUseCase: FetchRetrospectListUseCaseProtocol
+
+    private(set) var retrospects: [Retrospect] = []
+    var onRetrospectsFetched: (() -> Void)?
+
+    init(fetchRetrospectListUseCase: FetchRetrospectListUseCaseProtocol) {
+        self.fetchRetrospectListUseCase = fetchRetrospectListUseCase
+    }
+
+    func fetchRetrospects() {
+        Task {
+            do {
+                retrospects = try await fetchRetrospectListUseCase.execute()
+                onRetrospectsFetched?()
+            } catch {
+                // TODO: 에러 처리 (나중에 추가)
+            }
+        }
+    }
+}

--- a/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewModel.swift
+++ b/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewModel.swift
@@ -13,6 +13,7 @@ final class RetrospectListViewModel {
 
     private(set) var retrospects: [Retrospect] = []
     var onRetrospectsFetched: (() -> Void)?
+    var onError: ((String) -> Void)?
 
     init(fetchRetrospectListUseCase: FetchRetrospectListUseCaseProtocol) {
         self.fetchRetrospectListUseCase = fetchRetrospectListUseCase
@@ -24,7 +25,7 @@ final class RetrospectListViewModel {
                 retrospects = try await fetchRetrospectListUseCase.execute()
                 onRetrospectsFetched?()
             } catch {
-                // TODO: 에러 처리 (나중에 추가)
+                onError?(error.localizedDescription)
             }
         }
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈
<!-- closes #이슈번호 (머지 시 이슈 자동 닫힘) -->
closes #9

---

## ✨ What's this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

Presentation 레이어를 구현합니다. 앱 실행 → 회고 목록 화면 표시까지 ! (근데 이제 매우 기초인)

**추가된 파일:**
- `Application/DIContainer/DIContainer.swift` — 의존성 조립 (CoreDataStack → Repository → UseCase)
- `Presentation/Common/Coordinator/Coordinator.swift` — Coordinator Protocol
- `Presentation/Common/Coordinator/AppCoordinator.swift` — 앱 시작점, 화면 구성
- `Presentation/Retro/RetrospectListViewModel.swift` — 회고 목록 데이터 관리
- `Presentation/Retro/RetrospectListViewController.swift` — 회고 목록 UI (UITableView)

**수정된 파일:**
- `SceneDelegate.swift` — AppCoordinator 연결

---

### 🏗️ 구현 방식
<!-- 핵심 기술적 결정, 아키텍처 선택 이유, 사용한 패턴 등 -->

#### DIContainer

CoreDataStack → Repository → UseCase를 한 곳에서 조립합니다.
`lazy var`로 필요한 시점에 초기화됩니다.
```swift
lazy var coreDataStack = CoreDataStack()
lazy var retrospectRepository = CoreDataRetrospectRepository(coreDataStack: coreDataStack)
lazy var fetchRetrospectListUseCase = FetchRetrospectListUseCase(repository: retrospectRepository)
```

#### Coordinator 패턴

화면 전환 로직을 ViewController에서 분리했습니다.
AppCoordinator가 window, navigationController, DIContainer를 갖고 첫 화면을 구성합니다.

```
SceneDelegate → AppCoordinator.start() → ViewController 생성 → window 표시
```

#### ViewModel → ViewController 바인딩 (closure)

ViewModel의 데이터 변경을 클로저로 ViewController에 전달합니다.

```swift
// ViewModel
var onRetrospectsFetched: (() -> Void)?

func fetchRetrospects() {
    Task {
        retrospects = try await useCase.execute()
        onRetrospectsFetched?()
    }
}

// ViewController
viewModel.onRetrospectsFetched = { [weak self] in
    DispatchQueue.main.async {
        self?.tableView.reloadData()
    }
}
```

#### UITableView

코드 기반 UITableView로 회고 목록을 표시합니다.
- `translatesAutoresizingMaskIntoConstraints = false` + NSLayoutConstraint로 오토레이아웃
- `UITableViewDataSource` extension으로 분리
- `UITableViewCell(style: .subtitle)` — 제목 + 상태 표시

---

### 📖 앞으로 공부해야 할 것 → 코드만 썼지 자세히 모르는 것들

- **Coordinator 패턴**: ViewController에서 화면 전환을 분리하는 이유와 구현 방식
- **UITableView 기본**: dataSource, register, dequeueReusableCell, NSLayoutConstraint
- **closure 바인딩**: ViewModel → ViewController 간 데이터 변경 알림 패턴
- **SceneDelegate + UIWindow**: Storyboard 없이 코드로 window 설정. `self.window = window` 필수!
- **오토레이아웃**: safeAreaLayoutGuide, NSLayoutConstraint.activate

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 성공

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 다음 PR에서 빌트인 포맷 초기 데이터(KPT, 4Ls, SSC)와 회고 작성 화면을 진행합니다!
