### PR TITLE
♻️ Refactor: #21 Copilot 코드 리뷰 반영 (Presentation 레이어)

### DIFF
--- a/RetroApp/RetroApp/Application/SceneDelegate.swift
+++ b/RetroApp/RetroApp/Application/SceneDelegate.swift
@@ -1,8 +1,10 @@
+import OSLog
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     private var coordinator: AppCoordinator?
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.kimjihye.RetroApp", category: "SceneDelegate")
 
     func scene(
         _ scene: UIScene,
@@ -27,6 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 self.coordinator = coordinator
                 coordinator.start()
             } catch {
+                logger.error("CoreDataStack initialization failed: \(error, privacy: .public)")
                 // TODO: 에러 UI 표시 예정
             }
         }

--- a/RetroApp/RetroApp/Application/SceneDelegate.swift
+++ b/RetroApp/RetroApp/Application/SceneDelegate.swift
@@ -15,16 +15,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = window
 
         Task {
-            let coreDataStack = try await CoreDataStack()
-            let diContainer = DIContainer(coreDataStack: coreDataStack)
-            let navigationController = UINavigationController()
-            let coordinator = AppCoordinator(
-                navigationController: navigationController,
-                diContainer: diContainer,
-                window: window
-            )
-            self.coordinator = coordinator
-            coordinator.start()
+            do {
+                let coreDataStack = try await CoreDataStack()
+                let diContainer = DIContainer(coreDataStack: coreDataStack)
+                let navigationController = UINavigationController()
+                let coordinator = AppCoordinator(
+                    navigationController: navigationController,
+                    diContainer: diContainer,
+                    window: window
+                )
+                self.coordinator = coordinator
+                coordinator.start()
+            } catch {
+                // TODO: 에러 UI 표시 예정
+            }
         }
     }
 

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -54,6 +54,12 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     func saveAll(_ items: [RetrospectItem]) async throws -> [RetrospectItem] {
         guard let firstItem = items.first else { return items }
 
+        for item in items {
+            guard item.retrospectId == firstItem.retrospectId else {
+                throw RetrospectError.mismatchedRetrospectId
+            }
+        }
+
         let request = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         request.predicate = NSPredicate(format: "id == %@", firstItem.retrospectId as CVarArg)
 
@@ -62,7 +68,7 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
         guard let retrospect = response.first else {
             throw RetrospectError.retrospectNotFound
         }
-
+        
         for item in items {
             _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
         }
@@ -119,6 +125,12 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
     ///   - items: 새로 저장할 항목 배열
     /// - Returns: 저장된 항목 배열
     func replaceAll(retrospectId: UUID, items: [RetrospectItem]) async throws -> [RetrospectItem] {
+        for item in items {
+            guard item.retrospectId == retrospectId else {
+                throw RetrospectError.mismatchedRetrospectId
+            }
+        }
+
         let retroRequest = NSFetchRequest<RetrospectEntity>(entityName: "RetrospectEntity")
         retroRequest.predicate = NSPredicate(format: "id == %@", retrospectId as CVarArg)
 
@@ -138,9 +150,6 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
         }
 
         for item in items {
-            guard item.retrospectId == retrospectId else {
-                throw RetrospectError.mismatchedRetrospectId
-            }
             _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
         }
 

--- a/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
+++ b/RetroApp/RetroApp/Data/Repository/CoreDataRetrospectItemRepository.swift
@@ -68,7 +68,6 @@ final class CoreDataRetrospectItemRepository: RetrospectItemRepositoryProtocol {
         guard let retrospect = response.first else {
             throw RetrospectError.retrospectNotFound
         }
-        
         for item in items {
             _ = RetrospectItemMapper.toManagedObject(item, retrospect: retrospect, context: coreDataStack.viewContext)
         }

--- a/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewController.swift
+++ b/RetroApp/RetroApp/Presentation/Retro/RetrospectListViewController.swift
@@ -73,7 +73,7 @@ final class RetrospectListViewController: UIViewController {
             }
         }
 
-        viewModel.onError = { message in
+        viewModel.onError = { _ in
             // TODO: Alert으로 교체 예정
         }
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈
<!-- closes #이슈번호 (머지 시 이슈 자동 닫힘) -->
closes #21

---

## ✨ What's this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

머지 후 Copilot 코드 리뷰에서 지적된 사항들을 반영합니다.

---

### 🏗️ 구현 방식
<!-- 핵심 기술적 결정, 아키텍처 선택 이유, 사용한 패턴 등 -->

#### 1. replaceAll guard 검증을 삭제 전으로 이동

기존에는 삭제 후 guard 검증이 실행되어, 검증 실패 시 context에 삭제 대기 상태가 남는 문제가 있었습니다.
검증 → 조회 → 삭제 → 저장 순서로 변경하여 잘못된 데이터가 오면 아무것도 건드리지 않고 바로 에러를 반환합니다.

#### 2. saveAll에 retrospectId 검증 추가

모든 item의 retrospectId가 동일한지 검증하는 guard를 추가했습니다. replaceAll과 동일하게 검증 → 조회 → 저장 순서를 따릅니다.

#### 3. SceneDelegate Task 에러 처리

CoreDataStack 초기화가 실패해도 무시되는 문제를 do/catch로 처리했습니다. 현재 catch에서는 TODO로 두었으며, 에러 UI는 후속 PR에서 구현 예정입니다.

#### 4. onError 미사용 파라미터 수정

아직 얼럿 UI가 없어 message를 사용하지 않으므로 컴파일 경고 방지를 위해 `_`로 변경했습니다.

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 성공

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- performAndWait throwing은 Swift 5.9+에서 지원되므로 현재 코드 유지
- 에러 UI(얼럿)는 후속 PR에서 구현 예정

```
/// iOS 공식 문서
@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
public func performAndWait<T>(_ block: () throws -> T) rethrows -> T
```

performAndWait의 throwing 클로저는 iOS 15+에서 공식 지원됩니다.
https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/3802019-performandwait

현재 앱의 최소 타겟이 iOS 15 이상이므로 기존 코드를 유지합니다. (너가 틀린거야 코파일럿 ..)